### PR TITLE
Fix submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/direwolf"]
 path = external/direwolf
-url = https://github.com/kf0tke/wx-heliox-direwolf
+url = https://github.com/kf0tke/wx-helios-direwolf


### PR DESCRIPTION
## Summary
- fix the URL for the `external/direwolf` submodule

## Testing
- `pip install psutil`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a5c426f88323a186046a37fbf7cb