### PR TITLE
Update README with build step for ws-helios-direwolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ The project will expand to include several related components:
 - Python 3.x
 - `psutil` Python package
 
+## Building ws-helios-direwolf
+
+This repository includes the [ws-helios-direwolf](https://github.com/kf0tke/wx-helios-direwolf) subproject used to provide the Direwolf TNC. Build it before running the telemetry beacon:
+
+```bash
+
+git submodule update --init
+cd external/direwolf
+mkdir build && cd build
+cmake ..
+make -j4
+sudo make install
+```
+
+
 ## Configuration
 
 Copy the template and edit the values for your station:


### PR DESCRIPTION
## Summary
- document how to compile the `ws-helios-direwolf` subproject

## Testing
- `pip install psutil`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d55d717c832396c6d8687cce8fb1