### PR TITLE
Add wxnow file output to Ecowitt listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ hubTelemetry.conf
 
 # Telemetry sequence file (runtime state)
 telemetry.seq
+runtime/
 
 # IDE/editor temporary files
 *.swp

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Set callsign, coordinates, symbol table, path and destination. Install the depen
 pip install -r requirements.txt
 ```
 
+## Runtime directory
+
+Scripts create writable files under `runtime/` in the project root. For example,
+`ecowitt-listener.py` writes the latest APRS frame to `runtime/wxnow.txt` each
+time it logs data.
+
 ## License
 
 This project is licensed under the GNU General Public License version 2. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- add ability to write the latest APRS frame to `/runtime/wxnow.txt`
- store a UTC timestamp and frame in the file whenever data is logged
- ignore runtime directory artifacts
- document runtime directory purpose

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b33e74ddc8323aec981f051991e50