### PR TITLE
Add pytest skip for missing psutil

### DIFF
--- a/tests/test_kiss.py
+++ b/tests/test_kiss.py
@@ -1,5 +1,11 @@
 import unittest
 from unittest.mock import patch
+import pytest
+
+# Skip these tests entirely if psutil isn't available since hubTelemetry
+# depends on it at import time.
+pytest.importorskip("psutil")
+
 import hubTelemetry
 
 class DummySocket:


### PR DESCRIPTION
## Summary
- make tests a package so test modules can import hubTelemetry
- skip tests if psutil isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b561fe8708323b51293632710118e