### PR TITLE
Remove telemetry sequence placeholder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ __pycache__/
 hubTelemetry.conf
 wx-helios.conf
 
-# Telemetry sequence file (runtime state)
-telemetry.seq
 runtime/
 
 # IDE/editor temporary files

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Copy the template and edit the values for your station:
 cp wx-helios.conf.template wx-helios.conf
 ```
 
+Telemetry sequence counters are no longer used, so the previous
+`[TELEMETRY]/sequence_file` option has been removed.
+
 The file contains APRS beacon details and Ecowitt listener settings. Install the dependencies with:
 
 ```bash


### PR DESCRIPTION
## Summary
- remove old telemetry sequence file from `.gitignore`
- note in README that telemetry sequence counters are not used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7204d2cc832387381489da635ecc