### PR TITLE
Allow rigctld params in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,26 @@ This uses `direwolf.conf` (copied from the template if missing), ensures the
 ## Running rigctld
 
 Launch `rigctld` for radio control with the helper script. Pass the rig model ID
-and the `/dev/ttyUSB` device number:
+and the `/dev/ttyUSB` device number, or omit both to use the values from the
+configuration file:
 
 ```bash
 ./run_rigctld.sh <rig-id> <usb-num>
+# or
+./run_rigctld.sh
 ```
 
 For example, to start model `503` on `/dev/ttyUSB0`:
 
 ```bash
 ./run_rigctld.sh 503 0
+```
+
+If ``wx-helios.conf`` contains a ``[RIG]`` section with ``rig_id`` and
+``usb_num`` set, you can simply run:
+
+```bash
+./run_rigctld.sh
 ```
 
 
@@ -91,10 +101,12 @@ cp wx-helios.conf.template wx-helios.conf
 Telemetry sequence counters are no longer used, so the previous
 `[TELEMETRY]/sequence_file` option has been removed.
 
-The file contains APRS beacon details and Ecowitt listener settings. Two
-boolean options control whether the Ecowitt listener and telemetry beacon run
-at all: ``[ECOWITT]/enabled`` and ``[HUBTELEMETRY]/enabled``. Set them to ``no``
-to disable the corresponding service. Install the dependencies with:
+The file contains APRS beacon details, Ecowitt listener settings and radio
+parameters. Two boolean options control whether the Ecowitt listener and
+telemetry beacon run at all: ``[ECOWITT]/enabled`` and ``[HUBTELEMETRY]/enabled``.
+Set them to ``no`` to disable the corresponding service. The ``[RIG]`` section
+provides ``rig_id`` and ``usb_num`` for ``rigctld``. Install the dependencies
+with:
 
 ```bash
 pip install -r requirements.txt
@@ -108,12 +120,13 @@ time it logs data.
 
 ## Combined launcher
 
-`main.py` starts all services at once. Pass the rig model and USB number just as
-you would to `run_rigctld.sh`. The telemetry beacon runs every hour until the
-program is stopped.
+`main.py` starts all services at once. It reads the rig model and USB number
+from ``wx-helios.conf`` by default. Command-line options ``--rig-id`` and
+``--usb-num`` override the configuration if needed. The telemetry beacon runs
+every hour until the program is stopped.
 
 ```bash
-python3 main.py <rig-id> <usb-num>
+python3 main.py
 ```
 
 Use `--telemetry-interval` to change the beacon period if needed.

--- a/config.py
+++ b/config.py
@@ -54,3 +54,17 @@ def load_hubtelemetry_config():
         return {"enabled": True}
     hub = cfg[section]
     return {"enabled": hub.getboolean("enabled", True)}
+
+
+def load_rig_config():
+    cfg = _get_config()
+    section = "RIG"
+    if section not in cfg:
+        return {}
+    rig = cfg[section]
+    result = {}
+    if "rig_id" in rig:
+        result["rig_id"] = int(rig.get("rig_id", 0))
+    if "usb_num" in rig:
+        result["usb_num"] = int(rig.get("usb_num", 0))
+    return result

--- a/main.py
+++ b/main.py
@@ -70,8 +70,8 @@ def run_hubtelemetry():
 
 def main():
     parser = argparse.ArgumentParser(description="wx-helios combined launcher")
-    parser.add_argument("rig_id", type=int, help="rig model ID")
-    parser.add_argument("usb_num", type=int, help="/dev/ttyUSB device number")
+    parser.add_argument("--rig-id", type=int, help="rig model ID")
+    parser.add_argument("--usb-num", type=int, help="/dev/ttyUSB device number")
     parser.add_argument(
         "--telemetry-interval",
         type=int,
@@ -79,6 +79,14 @@ def main():
         help="seconds between telemetry beacons",
     )
     args = parser.parse_args()
+
+    rig_cfg = config.load_rig_config()
+    if args.rig_id is None:
+        args.rig_id = rig_cfg.get("rig_id")
+    if args.usb_num is None:
+        args.usb_num = rig_cfg.get("usb_num")
+    if args.rig_id is None or args.usb_num is None:
+        parser.error("rig_id and usb_num must be provided via command line or configuration")
 
     logging.basicConfig(
         level=logging.INFO,

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -3,13 +3,25 @@
 
 set -e
 
-if [ "$#" -ne 2 ]; then
+usage() {
     echo "Usage: $0 <rig-id> <ttyUSB number>" >&2
+    echo "       $0" >&2
     echo "Example: $0 503 0" >&2
     exit 1
-fi
+}
 
-RIG_ID="$1"
-USB_NUM="$2"
+if [ "$#" -eq 2 ]; then
+    RIG_ID="$1"
+    USB_NUM="$2"
+elif [ "$#" -eq 0 ]; then
+    RIG_ID=$(python3 -c 'import config; print(config.load_rig_config().get("rig_id", ""))')
+    USB_NUM=$(python3 -c 'import config; print(config.load_rig_config().get("usb_num", ""))')
+    if [ -z "$RIG_ID" ] || [ -z "$USB_NUM" ]; then
+        echo "Rig settings not found in configuration" >&2
+        usage
+    fi
+else
+    usage
+fi
 
 exec rigctld -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -46,3 +46,9 @@ lon = 10854.32W
 [HUBTELEMETRY]
 # Enable or disable the telemetry beacon
 enabled = yes
+
+[RIG]
+# Rig model ID for rigctld
+rig_id = 503
+# USB device number for /dev/ttyUSB{usb_num}
+usb_num = 0


### PR DESCRIPTION
## Summary
- support `[RIG]` section in configuration
- load rig settings from config in main launcher
- default `run_rigctld.sh` to config values
- document new configuration options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7d40e6d08323becc0c88da940459