### PR TITLE
Add enable flags for Direwolf and rigctld

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Start the Direwolf TNC with the helper script:
 This uses `direwolf.conf` (copied from the template if missing), ensures the
 `runtime/` directory exists and passes `runtime/wxnow.txt` to Direwolf using the
 `-w` option. Logs are written to `direwolf.log`.
+Set `[DIREWOLF]/enabled` to `no` in `wx-helios.conf` to skip starting Direwolf.
 
 ## Running rigctld
 
@@ -88,6 +89,7 @@ If ``wx-helios.conf`` contains a ``[RIG]`` section with ``rig_id`` and
 ```bash
 ./run_rigctld.sh
 ```
+Set `[RIG]/enabled` to `no` to disable launching ``rigctld``.
 
 
 ## Configuration
@@ -102,11 +104,11 @@ Telemetry sequence counters are no longer used, so the previous
 `[TELEMETRY]/sequence_file` option has been removed.
 
 The file contains APRS beacon details, Ecowitt listener settings and radio
-parameters. Two boolean options control whether the Ecowitt listener and
-telemetry beacon run at all: ``[ECOWITT]/enabled`` and ``[HUBTELEMETRY]/enabled``.
-Set them to ``no`` to disable the corresponding service. The ``[RIG]`` section
-provides ``rig_id`` and ``usb_num`` for ``rigctld``. Install the dependencies
-with:
+parameters. Each service can be disabled with an ``enabled`` option:
+``[ECOWITT]/enabled`` for the listener, ``[HUBTELEMETRY]/enabled`` for the
+telemetry beacon, ``[DIREWOLF]/enabled`` for the TNC and ``[RIG]/enabled`` for
+``rigctld``. The ``[RIG]`` section also provides ``rig_id`` and ``usb_num`` for
+``rigctld``. Install the dependencies with:
 
 ```bash
 pip install -r requirements.txt

--- a/config.py
+++ b/config.py
@@ -56,13 +56,22 @@ def load_hubtelemetry_config():
     return {"enabled": hub.getboolean("enabled", True)}
 
 
+def load_direwolf_config():
+    cfg = _get_config()
+    section = "DIREWOLF"
+    if section not in cfg:
+        return {"enabled": True}
+    dw = cfg[section]
+    return {"enabled": dw.getboolean("enabled", True)}
+
+
 def load_rig_config():
     cfg = _get_config()
     section = "RIG"
     if section not in cfg:
-        return {}
+        return {"enabled": True}
     rig = cfg[section]
-    result = {}
+    result = {"enabled": rig.getboolean("enabled", True)}
     if "rig_id" in rig:
         result["rig_id"] = int(rig.get("rig_id", 0))
     if "usb_num" in rig:

--- a/run_direwolf.sh
+++ b/run_direwolf.sh
@@ -7,6 +7,16 @@ CONF="direwolf.conf"
 RUNTIME_DIR="runtime"
 WXNOW="$RUNTIME_DIR/wxnow.txt"
 
+ENABLED=$(python3 - <<'EOF'
+import config
+print("yes" if config.load_direwolf_config().get("enabled", True) else "no")
+EOF
+)
+if [ "$ENABLED" != "yes" ]; then
+    echo "Direwolf disabled in configuration" >&2
+    exit 0
+fi
+
 # If the local configuration doesn't exist, create it from the template
 if [ ! -f "$CONF" ]; then
     cp direwolf.conf.template "$CONF"

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -24,4 +24,14 @@ else
     usage
 fi
 
+ENABLED=$(python3 - <<'EOF'
+import config
+print("yes" if config.load_rig_config().get("enabled", True) else "no")
+EOF
+)
+if [ "$ENABLED" != "yes" ]; then
+    echo "rigctld disabled in configuration" >&2
+    exit 0
+fi
+
 exec rigctld -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -30,6 +30,10 @@ destination = APZ001
 # Optional software version string
 version = v5
 
+[DIREWOLF]
+# Enable or disable the Direwolf TNC
+enabled = yes
+
 [ECOWITT]
 # Enable or disable the Ecowitt listener
 enabled = yes
@@ -48,6 +52,8 @@ lon = 10854.32W
 enabled = yes
 
 [RIG]
+# Enable or disable rigctld
+enabled = yes
 # Rig model ID for rigctld
 rig_id = 503
 # USB device number for /dev/ttyUSB{usb_num}


### PR DESCRIPTION
## Summary
- allow wx-helios to enable/disable Direwolf and rigctld helpers
- expose new flags via config file and scripts
- document the new configuration options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7fdcd50c8323a095df9ebc966f43