### PR TITLE
Add hamlib external submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/direwolf"]
 path = external/direwolf
 url = https://github.com/kf6ufo/wx-helios-direwolf.git
+[submodule "external/hamlib"]
+path = external/hamlib
+url = https://github.com/kf6ufo/wx-helios-hamlib.git

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ This repository includes the [wx-helios-direwolf](https://github.com/kf6ufo/wx-h
 ./build_direwolf.sh
 ```
 
+## Building wx-helios-hamlib
+
+To provide the `rigctld` daemon, this repository includes the
+[wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodule.
+Build it with the helper script:
+
+```bash
+./build_hamlib.sh
+```
+
 ## Running wx-helios-direwolf
 
 Start the Direwolf TNC with the helper script:
@@ -76,6 +86,9 @@ configuration file:
 # or
 ./run_rigctld.sh
 ```
+
+If the `wx-helios-hamlib` submodule has been built, the script will use the
+local `rigctld` binary automatically.
 
 For example, to start model `503` on `/dev/ttyUSB0`:
 

--- a/build_hamlib.sh
+++ b/build_hamlib.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Build the wx-helios-hamlib submodule without installing
+
+set -e
+
+# Initialize submodule if needed
+if [ ! -d "external/hamlib" ] || [ ! -d "external/hamlib/.git" ]; then
+    git submodule update --init external/hamlib
+fi
+
+cd external/hamlib
+mkdir -p build
+cd build
+cmake ..
+make -j$(nproc)

--- a/external/hamlib/README.md
+++ b/external/hamlib/README.md
@@ -1,0 +1,6 @@
+This directory is a git submodule for the [wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) project.
+Initialize it after cloning with:
+
+```bash
+git submodule update --init external/hamlib
+```

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -34,4 +34,11 @@ if [ "$ENABLED" != "yes" ]; then
     exit 0
 fi
 
-exec rigctld -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531
+RIGCTLD="rigctld"
+if [ -x "external/hamlib/build/rigctld" ]; then
+    RIGCTLD="external/hamlib/build/rigctld"
+elif [ -x "external/hamlib/build/src/rigctld" ]; then
+    RIGCTLD="external/hamlib/build/src/rigctld"
+fi
+
+exec "$RIGCTLD" -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531


### PR DESCRIPTION
## Summary
- add `wx-helios-hamlib` as an external Git submodule
- add helper script `build_hamlib.sh`
- prefer the locally built `rigctld` binary when running `run_rigctld.sh`
- document the new submodule in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b917cc18083238783d09ba6c2307d