### PR TITLE
Build hamlib before direwolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ This repository includes the
 [wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) and
 [wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodules used
 to provide the Direwolf TNC and the `rigctld` daemon. Build both with the helper
-script, which automatically pulls the latest sources from GitHub:
+script, which automatically pulls the latest sources from GitHub. Hamlib is
+built first so Direwolf can detect the libraries:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -15,5 +15,5 @@ build_module() {
     cd ../../..
 }
 
-build_module external/direwolf
 build_module external/hamlib
+build_module external/direwolf


### PR DESCRIPTION
## Summary
- build hamlib before direwolf
- note the new build order in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9af89f1c832380a4067de94c8b51