### PR TITLE
Remove hamlib submodule reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "external/direwolf"]
 path = external/direwolf
 url = https://github.com/kf6ufo/wx-helios-direwolf.git
-[submodule "external/hamlib"]
-path = external/hamlib
-url = https://github.com/kf6ufo/wx-helios-hamlib.git

--- a/README.md
+++ b/README.md
@@ -47,11 +47,9 @@ station that speaks the same protocol should also work.
 ## Building external components
 
 This repository includes the
-[wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) and
-[wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodules used
-to provide the Direwolf TNC and the `rigctld` daemon. Build both with the helper
-script, which automatically pulls the latest sources from GitHub. Hamlib is
-built first so Direwolf can detect the libraries:
+[wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) submodule
+used to provide the Direwolf TNC. Build it with the helper script, which
+automatically pulls the latest sources from GitHub:
 
 ```bash
 ./build_external.sh
@@ -82,8 +80,7 @@ configuration file:
 ./run_rigctld.sh
 ```
 
-If the `wx-helios-hamlib` submodule has been built, the script will use the
-local `rigctld` binary automatically.
+The script uses the system `rigctld` binary by default.
 
 For example, to start model `503` on `/dev/ttyUSB0`:
 

--- a/build_external.sh
+++ b/build_external.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build external submodules (Direwolf and Hamlib) without installing
+# Build external submodules (currently only Direwolf) without installing
 
 set -e
 
@@ -15,5 +15,4 @@ build_module() {
     cd ../../..
 }
 
-build_module external/hamlib
 build_module external/direwolf

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Start rigctld with the specified rig model and serial adapter
+# Start the system rigctld with the specified rig model and serial adapter
 
 set -e
 
@@ -35,10 +35,5 @@ if [ "$ENABLED" != "yes" ]; then
 fi
 
 RIGCTLD="rigctld"
-if [ -x "external/hamlib/build/rigctld" ]; then
-    RIGCTLD="external/hamlib/build/rigctld"
-elif [ -x "external/hamlib/build/src/rigctld" ]; then
-    RIGCTLD="external/hamlib/build/src/rigctld"
-fi
 
 exec "$RIGCTLD" -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531


### PR DESCRIPTION
## Summary
- drop wx-helios-hamlib from submodules
- update build script to only build Direwolf
- remove submodule lookup in rigctld launcher
- adjust README to reflect removal of hamlib

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bad0b04648323a6a05cf5d8c0e278