### PR TITLE
Restore hamlib external module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "external/direwolf"]
 path = external/direwolf
 url = https://github.com/kf6ufo/wx-helios-direwolf.git
+[submodule "external/hamlib"]
+path = external/hamlib
+url = https://github.com/kf6ufo/wx-helios-hamlib.git

--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ station that speaks the same protocol should also work.
 ## Building external components
 
 This repository includes the
-[wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) submodule
-used to provide the Direwolf TNC. Build it with the helper script, which
-automatically pulls the latest sources from GitHub:
+[wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) and
+[wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodules used
+to provide the Direwolf TNC and the `rigctld` daemon. Build both with the helper
+script, which automatically pulls the latest sources from GitHub. Hamlib is
+built first so Direwolf can detect the libraries:
 
 ```bash
 ./build_external.sh
@@ -80,7 +82,8 @@ configuration file:
 ./run_rigctld.sh
 ```
 
-The script uses the system `rigctld` binary by default.
+If the `wx-helios-hamlib` submodule has been built, the script will use the
+local `rigctld` binary automatically.
 
 For example, to start model `503` on `/dev/ttyUSB0`:
 

--- a/build_external.sh
+++ b/build_external.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Build external submodules (currently only Direwolf) without installing
+# Build external submodules (Direwolf and Hamlib) without installing
 
 set -e
 
@@ -15,4 +15,5 @@ build_module() {
     cd ../../..
 }
 
+build_module external/hamlib
 build_module external/direwolf

--- a/external/hamlib/README.md
+++ b/external/hamlib/README.md
@@ -1,0 +1,6 @@
+This directory is a git submodule for the [wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) project.
+Initialize it after cloning with:
+
+```bash
+git submodule update --init external/hamlib
+```

--- a/run_rigctld.sh
+++ b/run_rigctld.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Start the system rigctld with the specified rig model and serial adapter
+# Start rigctld with the specified rig model and serial adapter
 
 set -e
 
@@ -35,5 +35,10 @@ if [ "$ENABLED" != "yes" ]; then
 fi
 
 RIGCTLD="rigctld"
+if [ -x "external/hamlib/build/rigctld" ]; then
+    RIGCTLD="external/hamlib/build/rigctld"
+elif [ -x "external/hamlib/build/src/rigctld" ]; then
+    RIGCTLD="external/hamlib/build/src/rigctld"
+fi
 
 exec "$RIGCTLD" -m "$RIG_ID" -r "/dev/ttyUSB${USB_NUM}" -t 4531


### PR DESCRIPTION
## Summary
- re-introduce `wx-helios-hamlib` external reference
- update build script to build hamlib first
- look for a locally built `rigctld`
- document hamlib usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bae2cffd483239747f30777ad212d