### PR TITLE
Fix bare except in hubTelemetry

### DIFF
--- a/hubTelemetry.py
+++ b/hubTelemetry.py
@@ -96,7 +96,7 @@ def get_laptop_telemetry():
         temps = psutil.sensors_temperatures()
         if 'coretemp' in temps:
             cpu_temp = temps['coretemp'][0].current
-    except:
+    except Exception:
         cpu_temp = 0.0
 
     cpu_load = psutil.cpu_percent(interval=1)


### PR DESCRIPTION
## Summary
- replace a bare `except:` with `except Exception:` to follow Ruff's E722 rule

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc30f0f10832385025d8158623d20