### PR TITLE
Add bootstrap step to hamlib build

### DIFF
--- a/build_external.sh
+++ b/build_external.sh
@@ -8,6 +8,7 @@ build_hamlib() {
     local path="external/hamlib"
     git submodule update --init --remote "$path"
     cd "$path"
+    ./bootstrap
     mkdir -p build
     cd build
     ../configure


### PR DESCRIPTION
## Summary
- ensure `./bootstrap` is run before configuring `hamlib` in `build_external.sh`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc8a6d0008323b7fa23f02abbe05f