### PR TITLE
Fix bootstrap step in external build

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ git submodule update --init --recursive
 
 Then build both components with the helper script, which automatically pulls
 the latest sources from GitHub. Hamlib is built first so Direwolf can detect
-the libraries. The script invokes Hamlib's traditional `configure` build and
-uses CMake for Direwolf:
+the libraries. The script runs Hamlib's `./bootstrap` to create the
+`configure` script, invokes the traditional `configure` build and uses CMake
+for Direwolf:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -8,6 +8,7 @@ build_hamlib() {
     local path="external/hamlib"
     git submodule update --init --remote "$path"
     cd "$path"
+    ./bootstrap
     mkdir -p build
     cd build
     ../configure


### PR DESCRIPTION
## Summary
- run `./bootstrap` for hamlib before configuring
- document the bootstrap step in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc8a6d0008323b7fa23f02abbe05f