### PR TITLE
Install autotools before building hamlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ git submodule update --init --recursive
 
 Then build both components with the helper script, which automatically pulls
 the latest sources from GitHub. Hamlib is built first so Direwolf can detect
-the libraries. The script runs Hamlib's `./bootstrap` to create the
-`configure` script, invokes the traditional `configure` build and uses CMake
-for Direwolf:
+the libraries. The script installs GNU autotools if needed, runs Hamlib's
+`./bootstrap` to create the `configure` script, invokes the traditional
+`configure` build and uses CMake for Direwolf:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -3,8 +3,26 @@
 
 set -e
 
+# Ensure autoconf, automake and libtool are available
+ensure_autotools() {
+    if command -v autoreconf >/dev/null 2>&1 \
+        && command -v automake >/dev/null 2>&1 \
+        && command -v libtool >/dev/null 2>&1; then
+        return
+    fi
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y autoconf automake libtool
+    else
+        echo "Missing autoreconf, automake or libtool" >&2
+        echo "Please install the GNU autotools before building Hamlib" >&2
+        exit 1
+    fi
+}
+
 # Build Hamlib using autotools
 build_hamlib() {
+    ensure_autotools
     local path="external/hamlib"
     git submodule update --init --remote "$path"
     cd "$path"


### PR DESCRIPTION
## Summary
- install GNU autotools before building hamlib
- document automatic autotools install in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bca56cd648323b7ff6f38e8ff3cf9