### PR TITLE
Add run script for main program

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ from ``wx-helios.conf`` by default. Command-line options ``--rig-id`` and
 ``--usb-num`` override the configuration if needed. The telemetry beacon runs
 every hour until the program is stopped.
 
+The provided ``run.sh`` script launches ``main.py`` with a Python interpreter
+from a local virtual environment if one exists, falling back to ``python3``
+otherwise. Simply execute:
+
 ```bash
-python3 main.py
+./run.sh
 ```
 
 ## License

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Launch wx-helios using the project's Python environment.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Prefer local virtual environment if present
+if [ -x "$SCRIPT_DIR/venv/bin/python" ]; then
+    PYTHON="$SCRIPT_DIR/venv/bin/python"
+elif [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
+    PYTHON="$SCRIPT_DIR/.venv/bin/python"
+else
+    PYTHON="$(command -v python3)"
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/main.py" "$@"
+


### PR DESCRIPTION
## Summary
- add `run.sh` script to start the project using a local virtual environment if present
- document the new launcher in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd276f10c83238833a12018485704