### PR TITLE
Build hamlib locally and run rigctld from bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ to provide the Direwolf TNC and the `rigctld` daemon. Simply run the helper
 script to fetch the latest sources, install the build requirements and compile
 both projects. Hamlib is built first so Direwolf can detect the libraries. The
 script installs GNU autotools if needed, runs Hamlib's `./bootstrap` to create
-the `configure` script, invokes the traditional `configure` build and uses
-CMake for Direwolf:
+the `configure` script and installs `rigctld` to `bin/` so `main.py` can run it
+directly. Direwolf is built with CMake:
 
 ```bash
 ./build_external.sh

--- a/main.py
+++ b/main.py
@@ -31,8 +31,9 @@ def start_direwolf():
 
 
 def start_rigctld(rig_id: int, usb_num: int):
+    rigctld_bin = PROJECT_ROOT / "bin" / "rigctld"
     cmd = [
-        "rigctld",
+        str(rigctld_bin),
         "-m",
         str(rig_id),
         "-r",


### PR DESCRIPTION
## Summary
- build hamlib with install prefix `bin/`
- make `main.py` execute rigctld from the local `bin` directory
- document that `build_external.sh` installs `rigctld` to `bin/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be08012c48323be781a1023c83e7f