### PR TITLE
Install hamlib locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ to provide the Direwolf TNC and the `rigctld` daemon. Simply run the helper
 script to fetch the latest sources, install the build requirements and compile
 both projects. Hamlib is built first so Direwolf can detect the libraries. The
 script installs GNU autotools if needed, runs Hamlib's `./bootstrap` to create
-the `configure` script and installs `rigctld` to `bin/` so `main.py` can run it
-directly. Direwolf is built with CMake:
+the `configure` script and installs everything under the project root. Headers
+end up in `include/hamlib`, libraries under `lib/` and `rigctld` in `bin/` so
+`main.py` can run it directly. Direwolf is built with CMake:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -5,7 +5,7 @@ set -e
 
 # Absolute path to the project root
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkdir -p "$ROOT_DIR/bin"
+mkdir -p "$ROOT_DIR/bin" "$ROOT_DIR/include" "$ROOT_DIR/lib"
 
 # Ensure autoconf, automake and libtool are available
 ensure_autotools() {
@@ -34,14 +34,17 @@ build_hamlib() {
     mkdir -p build
     cd build
 
-    local prefix="$ROOT_DIR/bin"
+    # Install Hamlib directly under the project root so libraries and
+    # headers land in "lib" and "include/hamlib". This avoids writing to
+    # system directories like /usr/local.
+    local prefix="$ROOT_DIR"
 
     # First build with debug CFLAGS
-    ../configure CFLAGS="-g -O0"
+    ../configure --prefix="$prefix" CFLAGS="-g -O0"
     make -j"$(nproc)"
     make install
 
-    # Reconfigure to install binaries to the local bin directory
+    # Reconfigure to install binaries to the local prefix with release flags
     make distclean || true
     ../configure --prefix="$prefix"
     make -j"$(nproc)"


### PR DESCRIPTION
## Summary
- don't install hamlib to `/usr/local`
- update README about library locations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be55d39b08323b917ba12a20f8c75