### PR TITLE
Use hamlib binaries directly from build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ This repository includes the
 [wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) and
 [wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodules used
 to provide the Direwolf TNC and the `rigctld` daemon. Simply run the helper
-script to fetch the latest sources, install the build requirements and compile
-both projects. Hamlib is built first so Direwolf can detect the libraries. The
-script installs GNU autotools if needed, runs Hamlib's `./bootstrap` to create
-the `configure` script and installs everything under the project root. Headers
-end up in `include/hamlib`, libraries under `lib/` and `rigctld` in `bin/` so
-`main.py` can run it directly. Direwolf is built with CMake:
+script to fetch the latest sources and compile both projects. Hamlib is built
+first so Direwolf can detect the libraries. The script installs GNU autotools
+if needed and runs Hamlib's `./bootstrap` to create the `configure` script.
+The resulting `rigctld` binary is left inside
+`external/hamlib/build/tests/` and Direwolf is built with CMake:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -5,7 +5,6 @@ set -e
 
 # Absolute path to the project root
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-mkdir -p "$ROOT_DIR/bin" "$ROOT_DIR/include" "$ROOT_DIR/lib"
 
 # Ensure autoconf, automake and libtool are available
 ensure_autotools() {
@@ -34,24 +33,11 @@ build_hamlib() {
     mkdir -p build
     cd build
 
-    # Install Hamlib directly under the project root so libraries and
-    # headers land in "lib" and "include/hamlib". This avoids writing to
-    # system directories like /usr/local.
-    local prefix="$ROOT_DIR"
-    local libdir="$prefix/lib"
-    local includedir="$prefix/include"
-
-    # First build with debug CFLAGS
-    ../configure --prefix="$prefix" --libdir="$libdir" --includedir="$includedir" CFLAGS="-g -O0"
-    make -j"$(nproc)"
-    make install
-
-    # Reconfigure to install binaries to the local prefix with release flags
-    make distclean || true
-    ../configure --prefix="$prefix" --libdir="$libdir" --includedir="$includedir"
+    # Configure and build Hamlib without installing it. The rigctld binary will
+    # remain under the build/tests directory.
+    ../configure CFLAGS="-g -O0"
     make -j"$(nproc)"
     make check
-    make install
 
     cd ../../..
 }

--- a/main.py
+++ b/main.py
@@ -31,7 +31,9 @@ def start_direwolf():
 
 
 def start_rigctld(rig_id: int, usb_num: int):
-    rigctld_bin = PROJECT_ROOT / "bin" / "rigctld"
+    rigctld_bin = (
+        PROJECT_ROOT / "external" / "hamlib" / "build" / "tests" / "rigctld"
+    )
     cmd = [
         str(rigctld_bin),
         "-m",


### PR DESCRIPTION
## Summary
- simplify `build_external.sh` by removing the `make install` steps
- run `rigctld` directly from `external/hamlib/build/tests`
- update documentation for the new build approach

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bed5a5f0883238927c8a2d822b599