### PR TITLE
Update dummy rig config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ parameters. Each service can be disabled with an ``enabled`` option:
 ``[ECOWITT]/enabled`` for the listener, ``[HUBTELEMETRY]/enabled`` for the
 telemetry beacon, ``[DIREWOLF]/enabled`` for the TNC and ``[RIG]/enabled`` for
 ``rigctld``. The ``[RIG]`` section also provides ``rig_id`` and ``usb_num`` for
-``rigctld``. Install the dependencies with:
+``rigctld``; the template defaults to ``rig_id = 1`` for the Hamlib dummy radio.
+Install the dependencies with:
 
 ```bash
 pip install -r requirements.txt

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -54,7 +54,7 @@ enabled = yes
 [RIG]
 # Enable or disable rigctld
 enabled = yes
-# Rig model ID for rigctld
-rig_id = 503
+# Rig model ID for rigctld (1 = dummy rig)
+rig_id = 1
 # USB device number for /dev/ttyUSB{usb_num}
 usb_num = 0


### PR DESCRIPTION
## Summary
- default to the Hamlib dummy rig (ID 1)
- mention this dummy rig in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bf46aade08323812838dc0604b68b