### PR TITLE
Remove invalid '-w' flag from Direwolf launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,9 +23,8 @@ def start_direwolf():
         shutil.copy(PROJECT_ROOT / "direwolf.conf.template", conf)
     runtime_dir = PROJECT_ROOT / "runtime"
     runtime_dir.mkdir(exist_ok=True)
-    wxnow = runtime_dir / "wxnow.txt"
     direwolf_bin = PROJECT_ROOT / "external" / "direwolf" / "build" / "src" / "direwolf"
-    cmd = [str(direwolf_bin), "-c", str(conf), "-l", "direwolf.log", "-w", str(wxnow)]
+    cmd = [str(direwolf_bin), "-c", str(conf), "-l", "direwolf.log"]
     logging.info("Starting Direwolf: %s", " ".join(cmd))
     return subprocess.Popen(cmd)
 


### PR DESCRIPTION
## Summary
- remove unsupported `-w` option from Direwolf invocation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0cf6c8a8832385d88a542f6ad622