### PR TITLE
Fix rigctld port mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ The file contains APRS beacon details, Ecowitt listener settings and radio
 parameters. Each service can be disabled with an ``enabled`` option:
 ``[ECOWITT]/enabled`` for the listener, ``[HUBTELEMETRY]/enabled`` for the
 telemetry beacon, ``[DIREWOLF]/enabled`` for the TNC and ``[RIG]/enabled`` for
-``rigctld``. The ``[RIG]`` section also provides ``rig_id`` and ``usb_num`` for
-``rigctld``; the template defaults to ``rig_id = 1`` for the Hamlib dummy radio.
+``rigctld``. The ``[RIG]`` section also provides ``rig_id``, ``usb_num`` and
+``port`` for ``rigctld``; the template defaults to ``rig_id = 1`` for the
+Hamlib dummy radio. The ``port`` option must match the ``PTT RIG`` port in
+``direwolf.conf`` and is used by ``main.py`` when launching ``rigctld``.
 Install the dependencies with:
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -3,6 +3,10 @@ from pathlib import Path
 
 CONFIG_PATH = Path(__file__).resolve().parent / "wx-helios.conf"
 
+# Default TCP port for rigctld. This value must match the port used in
+# ``direwolf.conf.template`` on the ``PTT RIG`` line.
+RIGCTLD_PORT = 4534
+
 _config = None
 
 def _get_config():
@@ -76,4 +80,5 @@ def load_rig_config():
         result["rig_id"] = int(rig.get("rig_id", 0))
     if "usb_num" in rig:
         result["usb_num"] = int(rig.get("usb_num", 0))
+    result["port"] = int(rig.get("port", RIGCTLD_PORT))
     return result

--- a/direwolf.conf.template
+++ b/direwolf.conf.template
@@ -7,7 +7,7 @@ ADEVICE plughw:1,0
 CHANNEL 0
 MYCALL NOCALL-0
 MODEM 1200
-PTT RIG 2 localhost:4534
+PTT RIG 2 localhost:4534   # must match [RIG]/port in wx-helios.conf
 
 # Virtual TNC Server
 AGWPORT 8000

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def start_direwolf():
     return subprocess.Popen(cmd)
 
 
-def start_rigctld(rig_id: int, usb_num: int):
+def start_rigctld(rig_id: int, usb_num: int, port: int):
     rigctld_bin = (
         PROJECT_ROOT / "external" / "hamlib" / "build" / "tests" / "rigctld"
     )
@@ -40,7 +40,7 @@ def start_rigctld(rig_id: int, usb_num: int):
         "-r",
         f"/dev/ttyUSB{usb_num}",
         "-t",
-        "4531",
+        str(port),
     ]
     logging.info("Starting rigctld: %s", " ".join(cmd))
     return subprocess.Popen(cmd)
@@ -103,7 +103,11 @@ def main():
     direwolf_proc = start_direwolf()
     rigctld_proc = None
     if rig_cfg.get("enabled", True):
-        rigctld_proc = start_rigctld(args.rig_id, args.usb_num)
+        rigctld_proc = start_rigctld(
+            args.rig_id,
+            args.usb_num,
+            rig_cfg.get("port", config.RIGCTLD_PORT),
+        )
     else:
         logging.info("rigctld disabled in configuration")
     eco_server, eco_thread = start_ecowitt_listener()

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -58,3 +58,5 @@ enabled = yes
 rig_id = 1
 # USB device number for /dev/ttyUSB{usb_num}
 usb_num = 0
+# TCP port for rigctld (must match PTT RIG port in direwolf.conf)
+port = 4534


### PR DESCRIPTION
## Summary
- read a rigctld port from configuration with default 4534
- pass that port to `rigctld` when launched
- document the port in configuration templates and README
- clarify `direwolf.conf.template` that the port must match configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1b3584648323b24068151379c942