### PR TITLE
Update Direwolf build to use local Hamlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ script to fetch the latest sources and compile both projects. Hamlib is built
 first so Direwolf can detect the libraries. The script installs GNU autotools
 if needed and runs Hamlib's `./bootstrap` to create the `configure` script.
 The resulting `rigctld` binary is left inside
-`external/hamlib/build/tests/` and Direwolf is built with CMake:
+`external/hamlib/build/tests/` and Direwolf is built with CMake using our
+locally built Hamlib via `-DHAMLIB_ROOT_DIR`:
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -49,7 +49,8 @@ build_direwolf() {
     cd "$path"
     mkdir -p build
     cd build
-    cmake ..
+    local hamlib_root="$ROOT_DIR/external/hamlib/build"
+    cmake .. -DHAMLIB_ROOT_DIR="$hamlib_root"
     make -j"$(nproc)"
     cd ../../..
 }


### PR DESCRIPTION
## Summary
- pass `HAMLIB_ROOT_DIR` when building Direwolf so CMake finds the bundled hamlib
- document Hamlib directory usage in the build instructions

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cc15b6bd48323b6a6476faf0a7d74