### PR TITLE
Automate .venv setup in run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ other protocols, but currently there is only the **Ecowitt** daemon/listener.
 
 - Debian / Ubuntu / Raspberry Pi OS
 - Python 3.x
-- Python dependencies listed in `requirements.txt` (install into venv with `pip install -r requirements.txt`)
+- Python dependencies listed in `requirements.txt` (install into `.venv` with `pip install -r requirements.txt` or simply run `./run.sh`)
 
 ## Building external components
 
@@ -79,15 +79,16 @@ Install the dependencies inside this environment:
 pip install -r requirements.txt
 ```
 
-The `run.sh` script automatically uses this environment.
+The `run.sh` script automatically sets up, activates and uses this environment.
+If one doesn't exist it creates `.venv` and installs the requirements.
 
 ## Running kf6ufo-wx-helios
 
 `main.py` starts all the services and daemons, then schedules telemetry runs. 
 
-The provided ``run.sh`` script launches ``main.py`` with a Python interpreter
-from a local virtual environment if one exists, falling back to ``python3``
-otherwise. Simply execute:
+The provided ``run.sh`` script ensures the ``.venv`` environment exists,
+installs dependencies if necessary, activates it and then launches ``main.py`` using that interpreter.
+Simply execute:
 
 ```bash
 ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -5,14 +5,16 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Prefer local virtual environment if present
-if [ -x "$SCRIPT_DIR/venv/bin/python" ]; then
-    PYTHON="$SCRIPT_DIR/venv/bin/python"
-elif [ -x "$SCRIPT_DIR/.venv/bin/python" ]; then
-    PYTHON="$SCRIPT_DIR/.venv/bin/python"
-else
-    PYTHON="$(command -v python3)"
+VENV_DIR="$SCRIPT_DIR/.venv"
+
+# Create the environment if needed and install dependencies
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+    python3 -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/python" -m pip install -r "$SCRIPT_DIR/requirements.txt"
 fi
 
-exec "$PYTHON" "$SCRIPT_DIR/main.py" "$@"
+# Activate the environment so any subprocesses use its tools
+source "$VENV_DIR/bin/activate"
+
+exec python "$SCRIPT_DIR/main.py" "$@"
 


### PR DESCRIPTION
## Summary
- install dependencies only when creating `.venv`
- keep `run.sh` consistent by only using `.venv`
- activate `.venv` so subprocesses use it
- document the automatic setup and activation in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685d27a0f53483239379602b3fcf3638