### PR TITLE
Deduplicate latitude/longitude config

### DIFF
--- a/config.py
+++ b/config.py
@@ -37,16 +37,12 @@ def load_ecowitt_config():
         return {
             "port": 8080,
             "path": "/data/report",
-            "lat": "3742.12N",
-            "lon": "10854.32W",
             "enabled": True,
         }
     eco = cfg["ECOWITT"]
     return {
         "port": int(eco.get("port", 8080)),
         "path": eco.get("path", "/data/report"),
-        "lat": eco.get("lat", "3742.12N"),
-        "lon": eco.get("lon", "10854.32W"),
         "enabled": eco.getboolean("enabled", True),
     }
 

--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -15,8 +15,25 @@ ENABLED = cfg.get("enabled", True)
 PORT = cfg.get("port", 8080)
 PATH = cfg.get("path", "/data/report")
 RAIN_CACHE = deque(maxlen=24)      # store tuples (timestamp, hourly_inch)
-LAT = cfg.get("lat", "3742.12N")    # exactly 8 chars
-LON = cfg.get("lon", "10854.32W")   # exactly 9 chars
+
+try:
+    _callsign, _lat_dd, _lon_dd, *_ = config.load_aprs_config()
+except Exception:
+    _lat_dd = 0.0
+    _lon_dd = 0.0
+
+def _format_lat_lon(lat, lon):
+    ns = 'N' if lat >= 0 else 'S'
+    ew = 'E' if lon >= 0 else 'W'
+    lat_deg = int(abs(lat))
+    lat_min = (abs(lat) - lat_deg) * 60
+    lon_deg = int(abs(lon))
+    lon_min = (abs(lon) - lon_deg) * 60
+    lat_str = f"{lat_deg:02d}{lat_min:05.2f}{ns}"
+    lon_str = f"{lon_deg:03d}{lon_min:05.2f}{ew}"
+    return lat_str, lon_str
+
+LAT, LON = _format_lat_lon(_lat_dd, _lon_dd)
 POS_BLOCK = f"{LAT}/{LON}_"
 # directories
 PROJECT_ROOT = Path(__file__).resolve().parent.parent

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -43,9 +43,8 @@ port = 8080
 # URL path for uploads
 path = /data/report
 
-# Position block for wxnow.txt
-lat = 3742.12N
-lon = 10854.32W
+# Ecowitt listener uses the station latitude and longitude from the APRS
+# section to generate the ``wxnow.txt`` position block.
 
 [HUBTELEMETRY]
 # Enable or disable the telemetry beacon


### PR DESCRIPTION
## Summary
- remove `lat` and `lon` options from `ECOWITT` config
- generate wxnow position block from APRS latitude/longitude
- clean up configuration template to mention new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3e4875208323a0d0cb3082672f35