### PR TITLE
Add lat/lon formatting tests

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -22,7 +22,8 @@ except Exception:
     _lat_dd = 0.0
     _lon_dd = 0.0
 
-def _format_lat_lon(lat, lon):
+def format_lat_lon(lat, lon):
+    """Return APRS-formatted latitude and longitude strings."""
     ns = 'N' if lat >= 0 else 'S'
     ew = 'E' if lon >= 0 else 'W'
     lat_deg = int(abs(lat))
@@ -33,7 +34,7 @@ def _format_lat_lon(lat, lon):
     lon_str = f"{lon_deg:03d}{lon_min:05.2f}{ew}"
     return lat_str, lon_str
 
-LAT, LON = _format_lat_lon(_lat_dd, _lon_dd)
+LAT, LON = format_lat_lon(_lat_dd, _lon_dd)
 POS_BLOCK = f"{LAT}/{LON}_"
 # directories
 PROJECT_ROOT = Path(__file__).resolve().parent.parent

--- a/tests/test_ecowitt.py
+++ b/tests/test_ecowitt.py
@@ -59,3 +59,19 @@ def test_update_rain_24h_same_hour_replaces():
     p2 = {"dateutc": "2020-01-01 01:50:00", "hourlyrainin": "0.20"}
     assert mod.update_rain_24h(p2) == 20
     assert len(mod.RAIN_CACHE) == 1
+
+
+@pytest.mark.parametrize("lat,lon,expected_lat,expected_lon", [
+    (37.5, 122.25, "3730.00N", "12215.00E"),
+    (-37.5, 122.25, "3730.00S", "12215.00E"),
+    (37.5, -122.25, "3730.00N", "12215.00W"),
+    (-37.5, -122.25, "3730.00S", "12215.00W"),
+    (0, 0, "0000.00N", "00000.00E"),
+    (-0.1, -0.1, "0006.00S", "00006.00W"),
+    (12.3456, -98.7654, "1220.74N", "09845.92W"),
+])
+def test_format_lat_lon(lat, lon, expected_lat, expected_lon):
+    mod = load_module()
+    result_lat, result_lon = mod.format_lat_lon(lat, lon)
+    assert result_lat == expected_lat
+    assert result_lon == expected_lon


### PR DESCRIPTION
## Summary
- rename `_format_lat_lon` to `format_lat_lon` for clarity
- test latitude/longitude sign and formatting variants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d4b481a8083239c4aa901e906ac8b