### PR TITLE
Rename hubTelemetry module for naming consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 .pytest_cache/
 
 # Running conf file from template
-hubTelemetry.conf
+hub_telemetry.conf
 wx-helios.conf
 
 runtime/

--- a/config.py
+++ b/config.py
@@ -74,7 +74,7 @@ def load_daemon_modules():
 
 def load_telemetry_modules():
     """Return list of enabled telemetry module names."""
-    return _load_module_list("TELEMETRY", ["telemetry.hubTelemetry"])
+    return _load_module_list("TELEMETRY", ["telemetry.hub_telemetry"])
 
 
 def load_direwolf_config():

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -237,7 +237,7 @@ def main(argv=None):
     tele_cfg = config.load_hubtelemetry_config()
     if not tele_cfg.get("enabled", True):
         if args.debug:
-            print("hubTelemetry disabled in configuration")
+            print("hub_telemetry disabled in configuration")
         sys.exit(0)
 
     callsign, latitude, longitude, symbol_table, symbol, path, destination, version = config.load_aprs_config()

--- a/tests/test_kiss.py
+++ b/tests/test_kiss.py
@@ -2,11 +2,11 @@ import unittest
 from unittest.mock import patch
 import pytest
 
-# Skip these tests entirely if psutil isn't available since hubTelemetry
+# Skip these tests entirely if psutil isn't available since hub_telemetry
 # depends on it at import time.
 pytest.importorskip("psutil")
 
-import telemetry.hubTelemetry as hubTelemetry
+import telemetry.hub_telemetry as hub_telemetry
 
 class DummySocket:
     def __init__(self):
@@ -22,7 +22,7 @@ class TestKissEscaping(unittest.TestCase):
     def _run_send(self, payload):
         dummy = DummySocket()
         with patch('socket.create_connection', return_value=dummy):
-            hubTelemetry.send_via_kiss(payload)
+            hub_telemetry.send_via_kiss(payload)
         return dummy.sent
 
     def test_no_escape(self):

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -58,7 +58,7 @@ modules = daemons.ecowitt_listener
 [TELEMETRY]
 # Comma-separated list of telemetry modules to run periodically
 enabled = yes
-modules = telemetry.hubTelemetry
+modules = telemetry.hub_telemetry
 
 [RIG]
 # Enable or disable rigctld


### PR DESCRIPTION
## Summary
- rename `hubTelemetry.py` to `hub_telemetry.py`
- update imports and configuration default
- adjust `.gitignore` template name
- fix messages referencing the old module name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d533a75b48323ba034d793d38b271