### PR TITLE
Add cron based telemetry scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ for more options in handling PTT.
 If ``rigctld`` is enabled, be sure that the ``Direwolf`` port for ``rigctld`` is the same
 as is configured for ``rigctld`` in ``wx-helios,conf``
 
+Telemetry modules can be scheduled individually using cron syntax.  Add a
+``[TELEMETRY_SCHEDULES]`` section to ``wx-helios.conf`` mapping module names to
+their schedule expressions:
+
+```ini
+[TELEMETRY_SCHEDULES]
+telemetry.hub_telemetry = 0 * * * *
+#other.module = */15 * * * *
+```
+
 
 ## Running kf6ufo-wx-helios
 

--- a/config.py
+++ b/config.py
@@ -77,6 +77,16 @@ def load_telemetry_modules():
     return _load_module_list("TELEMETRY", ["telemetry.hub_telemetry"])
 
 
+def load_telemetry_schedules():
+    """Return mapping of telemetry module names to cron expressions."""
+    cfg = _get_config()
+    section = "TELEMETRY_SCHEDULES"
+    if section not in cfg:
+        return {}
+    sec = cfg[section]
+    return {name: expr for name, expr in sec.items()}
+
+
 def load_direwolf_config():
     cfg = _get_config()
     section = "DIREWOLF"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 psutil
+croniter

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -27,3 +27,20 @@ def test_daemons_custom(tmp_path, monkeypatch):
 def test_telemetry_custom(tmp_path, monkeypatch):
     write_config(tmp_path, "[TELEMETRY]\nmodules = t1, t2\n", monkeypatch)
     assert config.load_telemetry_modules() == ["t1", "t2"]
+
+
+def test_telemetry_schedules_default(tmp_path, monkeypatch):
+    write_config(tmp_path, "", monkeypatch)
+    assert config.load_telemetry_schedules() == {}
+
+
+def test_telemetry_schedules_values(tmp_path, monkeypatch):
+    write_config(
+        tmp_path,
+        "[TELEMETRY_SCHEDULES]\nfoo = 0 * * * *\nbar = */5 * * * *\n",
+        monkeypatch,
+    )
+    assert config.load_telemetry_schedules() == {
+        "foo": "0 * * * *",
+        "bar": "*/5 * * * *",
+    }

--- a/tests/test_main_schedule.py
+++ b/tests/test_main_schedule.py
@@ -1,0 +1,53 @@
+import sys
+import logging
+import pytest
+
+import main
+import config
+
+
+def test_scheduler_runs_at_cron_times(monkeypatch):
+    calls = []
+    current = 0
+
+    def fake_time():
+        return current
+
+    def fake_sleep(t):
+        nonlocal current
+        current += t
+
+    def fake_run(name):
+        calls.append((name, current))
+        if len(calls) >= 3:
+            raise KeyboardInterrupt()
+
+    monkeypatch.setattr(main.time, "time", fake_time)
+    monkeypatch.setattr(main.time, "sleep", fake_sleep)
+    monkeypatch.setattr(main.signal, "signal", lambda *a, **k: None)
+    monkeypatch.setattr(logging, "basicConfig", lambda **k: None)
+    monkeypatch.setattr(main, "start_direwolf", lambda: None)
+    monkeypatch.setattr(main, "start_rigctld", lambda *a, **k: None)
+    monkeypatch.setattr(main, "start_daemon_modules", lambda: [])
+    monkeypatch.setattr(config, "load_rig_config", lambda: {"enabled": False})
+    monkeypatch.setattr(config, "load_direwolf_config", lambda: {"enabled": False})
+    monkeypatch.setattr(config, "load_telemetry_modules", lambda: ["m1", "m2"])
+    monkeypatch.setattr(
+        config,
+        "load_telemetry_schedules",
+        lambda: {"m1": "*/2 * * * *", "m2": "*/5 * * * *"},
+    )
+    monkeypatch.setattr(main, "run_telemetry_module", fake_run)
+
+    argv = ["main.py", "--rig-id", "1", "--usb-num", "0", "--telemetry-interval", "60"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(KeyboardInterrupt):
+        main.main()
+
+    assert calls == [
+        ("m1", 120),
+        ("m1", 240),
+        ("m2", 300),
+    ]
+

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -60,6 +60,13 @@ modules = daemons.ecowitt_listener
 enabled = yes
 modules = telemetry.hub_telemetry
 
+[TELEMETRY_SCHEDULES]
+# Cron expressions for individual telemetry modules
+# Run hub telemetry at the top of each hour
+telemetry.hub_telemetry = 0 * * * *
+# Example: run another module every 15 minutes
+#other.module = */15 * * * *
+
 [RIG]
 # Enable or disable rigctld
 enabled = yes


### PR DESCRIPTION
## Summary
- allow cron style scheduling for telemetry modules
- document TELEMETRY_SCHEDULES section
- support cron based scheduling in main
- add croniter to requirements
- provide tests for new config loader and scheduler logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_685d5b8d94fc8323b660d7930dc25688