### PR TITLE
Add Direwolf telemetry support

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import re
+from pathlib import Path
+
+import config
+from telemetry import hub_telemetry
+
+LOG_PATH = Path(__file__).resolve().parent.parent / "direwolf.log"
+
+
+def parse_metrics(line):
+    """Extract metrics from a Direwolf telemetry line."""
+    metrics = {}
+    m = re.search(r"rcvq=(\d+)", line)
+    if m:
+        metrics["rcvq"] = int(m.group(1))
+    m = re.search(r"sendq=(\d+)", line)
+    if m:
+        metrics["sendq"] = int(m.group(1))
+    m = re.search(r"busy=([0-9.]+)", line)
+    if m:
+        metrics["busy"] = float(m.group(1))
+    return metrics
+
+
+def read_metrics(path=LOG_PATH):
+    """Return the most recent set of metrics from ``direwolf.log``."""
+    try:
+        with open(path, "r") as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return None
+    for line in reversed(lines):
+        if "busy=" in line and "sendq=" in line:
+            data = parse_metrics(line)
+            if data:
+                return data
+    return None
+
+
+def build_aprs_info(lat, lon, table, symbol, version, metrics):
+    pos = hub_telemetry.decimal_to_aprs(lat, lon, table, symbol)
+    comment = (
+        f"dw_busy={metrics.get('busy', 0):.1f} "
+        f"dw_rcvq={metrics.get('rcvq', 0)} "
+        f"dw_sendq={metrics.get('sendq', 0)} ver={version}"
+    )
+    return pos + comment
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Direwolf Telemetry Beacon")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+    args = parser.parse_args(argv)
+
+    cfg = config.load_direwolf_config()
+    if not cfg.get("enabled", True):
+        if args.debug:
+            print("direwolf telemetry disabled in configuration")
+        sys.exit(0)
+
+    metrics = read_metrics()
+    if not metrics:
+        if args.debug:
+            print("No telemetry metrics found")
+        sys.exit(1)
+
+    callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config()
+    info = build_aprs_info(lat, lon, table, symbol, ver, metrics)
+    frame = hub_telemetry.build_ax25_frame(dest, callsign, path, info)
+
+    if args.debug:
+        print(info)
+        print(frame.hex())
+    else:
+        hub_telemetry.send_via_kiss(frame)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import patch
+
+pytest.importorskip("psutil")
+
+import telemetry.direwolf_telemetry as dw
+from telemetry import hub_telemetry
+import config
+
+
+def test_parse_metrics():
+    line = "T: busy=12.5% cd=0 rcvq=3(0.0) sendq=2(0.0)"
+    result = dw.parse_metrics(line)
+    assert result == {"busy": 12.5, "rcvq": 3, "sendq": 2}
+
+
+def test_kiss_frame_generation(monkeypatch):
+    metrics = {"busy": 1.0, "rcvq": 2, "sendq": 3}
+
+    monkeypatch.setattr(config, "load_direwolf_config", lambda: {"enabled": True})
+    monkeypatch.setattr(dw, "read_metrics", lambda path=None: metrics)
+    monkeypatch.setattr(
+        config,
+        "load_aprs_config",
+        lambda: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
+    )
+
+    sent = []
+
+    def fake_send(frame):
+        sent.append(frame)
+
+    monkeypatch.setattr(hub_telemetry, "send_via_kiss", fake_send)
+
+    dw.main([])
+
+    info = dw.build_aprs_info(10.0, -100.0, "/", "Y", "v1", metrics)
+    expected = hub_telemetry.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
+
+    assert sent and sent[0] == expected

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -58,12 +58,14 @@ modules = daemons.ecowitt_listener
 [TELEMETRY]
 # Comma-separated list of telemetry modules to run periodically
 enabled = yes
-modules = telemetry.hub_telemetry
+modules = telemetry.hub_telemetry, telemetry.direwolf_telemetry
 
 [TELEMETRY_SCHEDULES]
 # Cron expressions for individual telemetry modules
 # Run hub telemetry at the top of each hour
 telemetry.hub_telemetry = 0 * * * *
+# Example: poll Dire Wolf telemetry every 5 minutes
+telemetry.direwolf_telemetry = */5 * * * *
 # Example: run another module every 15 minutes
 #other.module = */15 * * * *
 


### PR DESCRIPTION
## Summary
- add new telemetry module `direwolf_telemetry`
- integrate module in sample configuration
- test Direwolf telemetry parsing and frame building

## Testing
- `tests/runTests.sh` *(fails: Could not find a version that satisfies the requirement psutil)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a0ff15883239c61230be04a2d09