### PR TITLE
Improve tests run offline

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,2 @@
+psutil==5.9.5
+croniter==1.3.14

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -5,6 +5,14 @@ set -e
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_DIR="$REPO_DIR/.venv"
+WHEEL_DIR="$REPO_DIR/tests/wheels"
+
+# Determine requirements file. Prefer a lock file if present so the
+# versions are consistent when installing from wheels.
+REQ_FILE="$REPO_DIR/requirements.lock"
+if [ ! -f "$REQ_FILE" ]; then
+    REQ_FILE="$REPO_DIR/requirements.txt"
+fi
 
 # Create the environment if needed
 if [ ! -x "$VENV_DIR/bin/python" ]; then
@@ -14,12 +22,39 @@ fi
 # Activate the environment so any subprocesses use its tools
 source "$VENV_DIR/bin/activate"
 
-# Install project dependencies every run to ensure tests have everything
-python -m pip install -r "$REPO_DIR/requirements.txt"
+# Install project dependencies every run to ensure tests have everything.
+# If the online installation fails (for example due to lack of network
+# access), try to fall back to a local wheelhouse.
+install_reqs() {
+    python -m pip install -r "$REQ_FILE" "$@"
+}
+
+if ! install_reqs >/dev/null 2>&1; then
+    echo "Failed to install dependencies from PyPI. Attempting offline install..." >&2
+    if [ -d "$WHEEL_DIR" ]; then
+        install_reqs --no-index --find-links "$WHEEL_DIR" || {
+            echo "Could not install required packages from $WHEEL_DIR" >&2
+            exit 1
+        }
+    else
+        echo "No local wheel directory found at $WHEEL_DIR" >&2
+        exit 1
+    fi
+fi
 
 # Ensure pytest is available
 if ! python -m pip show pytest > /dev/null 2>&1; then
-    python -m pip install pytest
+    if ! python -m pip install pytest >/dev/null 2>&1; then
+        if [ -d "$WHEEL_DIR" ]; then
+            python -m pip install --no-index --find-links "$WHEEL_DIR" pytest || {
+                echo "pytest is not available and could not be installed" >&2
+                exit 1
+            }
+        else
+            echo "pytest is required but could not be installed" >&2
+            exit 1
+        fi
+    fi
 fi
 
 cd "$REPO_DIR/tests"

--- a/tests/wheels/README.md
+++ b/tests/wheels/README.md
@@ -1,0 +1,2 @@
+This directory may contain local wheel files for offline test runs.
+Place ``psutil`` and ``croniter`` wheels here if network access is unavailable.


### PR DESCRIPTION
## Summary
- improve tests/runTests.sh to fall back to local wheels if dependencies can't be installed from PyPI
- add a `requirements.lock` file with pinned versions
- document optional wheel house in `tests/wheels/README.md`

## Testing
- `bash tests/runTests.sh` *(fails: Could not install required packages from tests/wheels)*

------
https://chatgpt.com/codex/tasks/task_e_685d9ca85bfc83238d859fc752eeea0e