### PR TITLE
Fix test schedule warnings

### DIFF
--- a/tests/test_main_schedule.py
+++ b/tests/test_main_schedule.py
@@ -1,9 +1,19 @@
 import sys
 import logging
+import warnings
 import pytest
 
 import main
 import config
+
+# croniter versions < 1.4 trigger DeprecationWarnings on Python 3.12 when
+# using ``datetime.utcfromtimestamp`` internally. Silence these warnings so
+# the test output is clean.
+warnings.filterwarnings(
+    "ignore",
+    category=DeprecationWarning,
+    module=r"^croniter",
+)
 
 
 def test_scheduler_runs_at_cron_times(monkeypatch):


### PR DESCRIPTION
## Summary
- silence croniter deprecation warnings used during schedule tests

## Testing
- `tests/runTests.sh -q` *(fails: Could not find a version that satisfies the requirement psutil==5.9.5)*

------
https://chatgpt.com/codex/tasks/task_e_685da3a6cddc832389af02e9d8d59188