### PR TITLE
Fix direwolf telemetry log handling

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -26,9 +26,25 @@ def parse_metrics(line):
 
 
 def read_metrics(path=LOG_PATH):
-    """Return the most recent set of metrics from ``direwolf.log``."""
+    """Return the most recent set of metrics from ``direwolf.log``.
+
+    ``path`` may point directly to a log file or a directory containing
+    rotated log files.  When a directory is provided, the newest ``*.log``
+    file inside the directory is used.
+    """
+    p = Path(path)
+    if p.is_dir():
+        log_files = sorted(
+            [f for f in p.glob("*.log") if f.is_file()],
+            key=lambda f: f.stat().st_mtime,
+            reverse=True,
+        )
+        if not log_files:
+            return None
+        p = log_files[0]
+
     try:
-        with open(path, "r") as f:
+        with p.open("r") as f:
             lines = f.readlines()
     except FileNotFoundError:
         return None


### PR DESCRIPTION
## Summary
- read latest Direwolf metrics when log path is a directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_685da5a5f918832382b578d82d3c5dae