### PR TITLE
Add kiss_client daemon and queue integration

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,7 +69,10 @@ def _load_module_list(section, default):
 
 def load_daemon_modules():
     """Return list of enabled daemon module names."""
-    return _load_module_list("DAEMONS", ["daemons.ecowitt_listener"])
+    return _load_module_list(
+        "DAEMONS",
+        ["daemons.ecowitt_listener", "daemons.kiss_client"],
+    )
 
 
 def load_telemetry_modules():
@@ -94,6 +97,15 @@ def load_direwolf_config():
         return {"enabled": True}
     dw = cfg[section]
     return {"enabled": dw.getboolean("enabled", True)}
+
+
+def load_kiss_client_config():
+    cfg = _get_config()
+    section = "KISS_CLIENT"
+    if section not in cfg:
+        return {"enabled": True}
+    kc = cfg[section]
+    return {"enabled": kc.getboolean("enabled", True)}
 
 
 def load_rig_config():

--- a/daemons/kiss_client.py
+++ b/daemons/kiss_client.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Background KISS client daemon."""
+import socket
+import threading
+import queue
+import logging
+
+import config
+
+cfg = config.load_kiss_client_config()
+ENABLED = cfg.get("enabled", False)
+
+FRAME_QUEUE = queue.Queue()
+_stop = threading.Event()
+_socket = None
+
+
+def _escape(ax25_frame: bytes) -> bytes:
+    escaped = bytearray()
+    for b in ax25_frame:
+        if b == 0xC0:
+            escaped += b"\xDB\xDC"
+        elif b == 0xDB:
+            escaped += b"\xDB\xDD"
+        else:
+            escaped.append(b)
+    return b"\xC0\x00" + bytes(escaped) + b"\xC0"
+
+
+def _run():
+    global _socket
+    try:
+        _socket = socket.create_connection(("127.0.0.1", 8001))
+        while not _stop.is_set():
+            frame = FRAME_QUEUE.get()
+            if frame is None:
+                break
+            try:
+                _socket.send(_escape(frame))
+            except Exception:
+                logging.exception("Failed to send KISS frame")
+    except Exception:
+        logging.exception("kiss_client failed to connect")
+    finally:
+        if _socket:
+            try:
+                _socket.close()
+            except Exception:
+                pass
+
+
+class _Server:
+    def shutdown(self):
+        _stop.set()
+        FRAME_QUEUE.put(None)
+
+
+def start():
+    """Start the KISS client thread."""
+    if not ENABLED:
+        logging.info("kiss_client disabled in configuration")
+        return None, None
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    return _Server(), thread

--- a/shared_functions.py
+++ b/shared_functions.py
@@ -24,6 +24,14 @@ def send_via_kiss(ax25_frame):
     None
         This function sends data over the network and does not return anything.
     """
+    try:
+        from daemons import kiss_client
+        if getattr(kiss_client, "ENABLED", False) and hasattr(kiss_client, "FRAME_QUEUE"):
+            kiss_client.FRAME_QUEUE.put(ax25_frame)
+            return
+    except Exception:
+        pass
+
     escaped = bytearray()
     for b in ax25_frame:
         if b == 0xC0:

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -11,7 +11,10 @@ def write_config(tmp_path, text, monkeypatch):
 
 def test_daemons_default(tmp_path, monkeypatch):
     write_config(tmp_path, "", monkeypatch)
-    assert config.load_daemon_modules() == ["daemons.ecowitt_listener"]
+    assert config.load_daemon_modules() == [
+        "daemons.ecowitt_listener",
+        "daemons.kiss_client",
+    ]
 
 
 def test_daemons_disabled(tmp_path, monkeypatch):

--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -1,0 +1,23 @@
+import shared_functions as shared
+import daemons.kiss_client as kc
+
+
+def test_send_via_kiss_uses_daemon_queue(monkeypatch):
+    items = []
+
+    class DummyQueue:
+        def put(self, frame):
+            items.append(frame)
+
+    monkeypatch.setattr(kc, "FRAME_QUEUE", DummyQueue())
+    monkeypatch.setattr(kc, "ENABLED", True)
+
+    def fail(*a, **k):
+        raise AssertionError("socket should not be used")
+
+    monkeypatch.setattr(shared.socket, "create_connection", fail)
+
+    frame = b"\x01\x02"
+    shared.send_via_kiss(frame)
+
+    assert items == [frame]

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -78,3 +78,7 @@ rig_id = 1
 usb_num = 0
 # TCP port for rigctld (must match PTT RIG port in direwolf.conf)
 port = 4534
+
+[KISS_CLIENT]
+# Enable or disable the background KISS client
+enabled = yes


### PR DESCRIPTION
## Summary
- implement `daemons.kiss_client` for persistent KISS connection
- queue frames through the daemon when available
- add `KISS_CLIENT` section in config template and parser
- include kiss_client daemon in default list
- test queue usage via mocked daemon
- default KISS_CLIENT enabled by default

## Testing
- `tests/runTests.sh` *(fails: Could not install dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_685dd2ea1c0c8323907d6cdded0ebee4