### PR TITLE
Fix KISS client defaults and patch telemetry call

### DIFF
--- a/config.py
+++ b/config.py
@@ -103,7 +103,7 @@ def load_kiss_client_config():
     cfg = _get_config()
     section = "KISS_CLIENT"
     if section not in cfg:
-        return {"enabled": True}
+        return {"enabled": False}
     kc = cfg[section]
     return {"enabled": kc.getboolean("enabled", True)}
 

--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import config
 from telemetry import hub_telemetry
-from shared_functions import send_via_kiss
+import shared_functions
 
 LOG_PATH = Path(__file__).resolve().parent.parent / "direwolf.log"
 
@@ -92,7 +92,7 @@ def main(argv=None):
         print(info)
         print(frame.hex())
     else:
-        send_via_kiss(frame)
+        shared_functions.send_via_kiss(frame)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- disable KISS client by default when no config is present
- reference send_via_kiss through module so tests can patch it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0516ce408323b7b62131e3ae464d