### PR TITLE
Fix KISS frame sending when daemon is disabled

### DIFF
--- a/shared_functions.py
+++ b/shared_functions.py
@@ -26,7 +26,11 @@ def send_via_kiss(ax25_frame):
     """
     try:
         from daemons import kiss_client
-        if getattr(kiss_client, "ENABLED", False) and hasattr(kiss_client, "FRAME_QUEUE"):
+        if (
+            getattr(kiss_client, "ENABLED", False)
+            and hasattr(kiss_client, "FRAME_QUEUE")
+            and getattr(kiss_client, "_socket", None) is not None
+        ):
             kiss_client.FRAME_QUEUE.put(ax25_frame)
             return
     except Exception:

--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -11,6 +11,7 @@ def test_send_via_kiss_uses_daemon_queue(monkeypatch):
 
     monkeypatch.setattr(kc, "FRAME_QUEUE", DummyQueue())
     monkeypatch.setattr(kc, "ENABLED", True)
+    monkeypatch.setattr(kc, "_socket", object())
 
     def fail(*a, **k):
         raise AssertionError("socket should not be used")


### PR DESCRIPTION
## Summary
- ensure `send_via_kiss` only uses the daemon queue when the daemon is running
- update the queue test to set `_socket` so the new guard is satisfied

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e5cee59808323a4c81e288ca70fe3