### PR TITLE
Refactor AX.25 helpers

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -5,8 +5,7 @@ import re
 from pathlib import Path
 
 import config
-from telemetry import hub_telemetry
-import shared_functions
+from shared_functions import build_ax25_frame, decimal_to_aprs, send_via_kiss
 
 LOG_PATH = Path(__file__).resolve().parent.parent / "direwolf.log"
 
@@ -58,7 +57,7 @@ def read_metrics(path=LOG_PATH):
 
 
 def build_aprs_info(lat, lon, table, symbol, version, metrics):
-    pos = hub_telemetry.decimal_to_aprs(lat, lon, table, symbol)
+    pos = decimal_to_aprs(lat, lon, table, symbol)
     comment = (
         f"dw_busy={metrics.get('busy', 0):.1f} "
         f"dw_rcvq={metrics.get('rcvq', 0)} "
@@ -86,13 +85,13 @@ def main(argv=None):
 
     callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config()
     info = build_aprs_info(lat, lon, table, symbol, ver, metrics)
-    frame = hub_telemetry.build_ax25_frame(dest, callsign, path, info)
+    frame = build_ax25_frame(dest, callsign, path, info)
 
     if args.debug:
         print(info)
         print(frame.hex())
     else:
-        shared_functions.send_via_kiss(frame)
+        send_via_kiss(frame)
 
 
 if __name__ == "__main__":

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -5,82 +5,11 @@ import config
 import argparse
 import sys
 
-from shared_functions import send_via_kiss
-
-# Parse callsign with optional SSID
-def parse_callsign(full_call):
-    """Split a callsign of the form ``CALL-SSID``.
-
-    Parameters
-    ----------
-    full_call : str
-        Callsign optionally followed by ``-SSID``.
-
-    Returns
-    -------
-    tuple
-        Two-item tuple of the padded callsign and SSID number.
-    """
-    if '-' in full_call:
-        base, ssid = full_call.split('-')
-        ssid = int(ssid)
-    else:
-        base, ssid = full_call, 0
-    return base.ljust(6), ssid
-
-# AX.25 callsign encoding
-def encode_callsign(callsign, ssid):
-    """Encode a callsign and SSID using AX.25 formatting.
-
-    Parameters
-    ----------
-    callsign : str
-        Callsign padded to six characters.
-    ssid : int
-        SSID value.
-
-    Returns
-    -------
-    bytearray
-        Encoded bytes suitable for an AX.25 address field.
-    """
-    encoded = bytearray([(ord(c) << 1) for c in callsign])
-    encoded.append(((ssid & 0x0F) << 1) | 0x60)
-    return encoded
-
-# Build full AX.25 UI frame
-def build_ax25_frame(destination, source, path, info):
-    """Construct a UI frame according to the AX.25 protocol.
-
-    Parameters
-    ----------
-    destination : str
-        Destination callsign.
-    source : str
-        Source callsign.
-    path : list[str]
-        Digipeater path.
-    info : str
-        Payload for the information field.
-
-    Returns
-    -------
-    bytearray
-        Encoded AX.25 frame ready for transmission.
-    """
-    frame = bytearray()
-    dest_call, dest_ssid = parse_callsign(destination)
-    src_call, src_ssid = parse_callsign(source)
-    frame += encode_callsign(dest_call, dest_ssid)
-    frame += encode_callsign(src_call, src_ssid)
-    for hop in path:
-        path_call, path_ssid = parse_callsign(hop)
-        frame += encode_callsign(path_call, path_ssid)
-    frame[-1] |= 0x01  # End-of-address flag
-    frame += b'\x03'  # Control field (UI)
-    frame += b'\xF0'  # PID (no layer 3)
-    frame += info.encode('ascii')
-    return frame
+from shared_functions import (
+    send_via_kiss,
+    build_ax25_frame,
+    decimal_to_aprs,
+)
 
 # Collect system telemetry
 def get_laptop_telemetry():
@@ -116,37 +45,6 @@ def get_laptop_telemetry():
 
     return cpu_temp, cpu_load, uptime_hours, mem_percent, disk_percent, net_rx_mb, net_tx_mb
 
-# Convert decimal degrees to APRS position format
-def decimal_to_aprs(lat, lon, symbol_table, symbol):
-    """Convert decimal degrees to an APRS position string.
-
-    Parameters
-    ----------
-    lat : float
-        Latitude in decimal degrees.
-    lon : float
-        Longitude in decimal degrees.
-    symbol_table : str
-        Symbol table identifier ('/' or '\\').
-    symbol : str
-        APRS map symbol.
-
-    Returns
-    -------
-    str
-        Position string suitable for an APRS info field.
-    """
-    ns = 'N' if lat >= 0 else 'S'
-    ew = 'E' if lon >= 0 else 'W'
-    lat_deg = int(abs(lat))
-    lat_min = (abs(lat) - lat_deg) * 60
-    lon_deg = int(abs(lon))
-    lon_min = (abs(lon) - lon_deg) * 60
-
-    lat_str = f"{lat_deg:02d}{lat_min:05.2f}{ns}"
-    lon_str = f"{lon_deg:03d}{lon_min:05.2f}{ew}"
-
-    return f"!{lat_str}{symbol_table}{lon_str}{symbol}"
 
 # Build APRS info field with key=value pairs
 def build_aprs_info(

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 pytest.importorskip("psutil")
 
 import telemetry.direwolf_telemetry as dw
-from telemetry import hub_telemetry
 import shared_functions as shared
 import config
 
@@ -36,6 +35,6 @@ def test_kiss_frame_generation(monkeypatch):
     dw.main([])
 
     info = dw.build_aprs_info(10.0, -100.0, "/", "Y", "v1", metrics)
-    expected = hub_telemetry.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
+    expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected


### PR DESCRIPTION
## Summary
- add AX.25 frame helpers to `shared_functions`
- import new helpers in telemetry modules
- adjust Direwolf telemetry tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_685e62aa22288323a4ad4b3135ffad80