### PR TITLE
Refactor wxnow transmitter to use KISS

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -3,7 +3,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qsl
 from datetime import datetime, timedelta, timezone
 from collections import deque
-from shared_functions import send_via_wxnow
+from shared_functions import send_via_kiss
 import logging
 import time
 import threading
@@ -112,7 +112,7 @@ def log_params(client, params):
         logger.info("  %s: %s", k, params[k])
     frame = ecowitt_to_aprs(params)
     logger.info(frame)
-    send_via_wxnow(frame)
+    send_via_kiss(frame)
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -92,7 +92,7 @@ def main(argv=None):
         print(info)
         print(frame.hex())
     else:
-        shared_functions.send_via_kiss(frame)
+        shared_functions.send_raw_via_kiss(frame)
 
 
 if __name__ == "__main__":

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -5,7 +5,7 @@ import config
 import argparse
 import sys
 
-from shared_functions import send_via_kiss
+from shared_functions import send_raw_via_kiss
 
 # Parse callsign with optional SSID
 def parse_callsign(full_call):
@@ -236,7 +236,7 @@ def main(argv=None):
         print(ax25_frame.hex())
 
     if not args.debug:
-        send_via_kiss(ax25_frame)
+        send_raw_via_kiss(ax25_frame)
 
 
 if __name__ == "__main__":

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -31,7 +31,7 @@ def test_kiss_frame_generation(monkeypatch):
     def fake_send(frame):
         sent.append(frame)
 
-    monkeypatch.setattr(shared, "send_via_kiss", fake_send)
+    monkeypatch.setattr(shared, "send_raw_via_kiss", fake_send)
 
     dw.main([])
 

--- a/tests/test_kiss.py
+++ b/tests/test_kiss.py
@@ -22,7 +22,7 @@ class TestKissEscaping(unittest.TestCase):
     def _run_send(self, payload):
         dummy = DummySocket()
         with patch('socket.create_connection', return_value=dummy):
-            shared.send_via_kiss(payload)
+            shared.send_raw_via_kiss(payload)
         return dummy.sent
 
     def test_no_escape(self):

--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -2,7 +2,7 @@ import shared_functions as shared
 import daemons.kiss_client as kc
 
 
-def test_send_via_kiss_uses_daemon_queue(monkeypatch):
+def test_send_raw_via_kiss_uses_daemon_queue(monkeypatch):
     items = []
 
     class DummyQueue:
@@ -19,6 +19,6 @@ def test_send_via_kiss_uses_daemon_queue(monkeypatch):
     monkeypatch.setattr(shared.socket, "create_connection", fail)
 
     frame = b"\x01\x02"
-    shared.send_via_kiss(frame)
+    shared.send_raw_via_kiss(frame)
 
     assert items == [frame]

--- a/tests/test_wxnow.py
+++ b/tests/test_wxnow.py
@@ -1,9 +1,22 @@
 import shared_functions as shared
+from telemetry import hub_telemetry
+import config
 
 
-def test_send_via_wxnow(tmp_path, monkeypatch):
-    dest = tmp_path / "wxnow.txt"
-    monkeypatch.setattr(shared, "WXNOW", dest)
-    shared.send_via_wxnow("TESTFRAME")
-    lines = dest.read_text().splitlines()
-    assert lines[-1] == "TESTFRAME"
+def test_send_via_kiss(monkeypatch):
+    sent = []
+
+    def fake_send(frame):
+        sent.append(frame)
+
+    monkeypatch.setattr(shared, "send_raw_via_kiss", fake_send)
+    monkeypatch.setattr(
+        config,
+        "load_aprs_config",
+        lambda: ("SRC", 0.0, 0.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
+    )
+
+    shared.send_via_kiss("TEST")
+
+    expected = hub_telemetry.build_ax25_frame("DEST", "SRC", ["WIDE1-1"], "TEST")
+    assert sent == [expected]


### PR DESCRIPTION
## Summary
- replace `send_via_wxnow` with `send_via_kiss`
- rename byte frame sender to `send_raw_via_kiss`
- update Ecowitt listener and telemetry modules
- adjust associated tests

## Testing
- `tests/runTests.sh` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e67d504488323a1ddbd54b53cf9c7