### PR TITLE
Refactor to drop wxnow file handling

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -3,7 +3,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qsl
 from datetime import datetime, timedelta, timezone
 from collections import deque
-from shared_functions import send_via_wxnow
+from shared_functions import send_via_kiss
 import logging
 import time
 import threading
@@ -112,7 +112,7 @@ def log_params(client, params):
         logger.info("  %s: %s", k, params[k])
     frame = ecowitt_to_aprs(params)
     logger.info(frame)
-    send_via_wxnow(frame)
+    send_via_kiss(frame)
 
 
 class Handler(BaseHTTPRequestHandler):

--- a/shared_functions.py
+++ b/shared_functions.py
@@ -71,12 +71,6 @@ def decimal_to_aprs(lat: float, lon: float, symbol_table: str, symbol: str) -> s
 
     return f"!{lat_str}{symbol_table}{lon_str}{symbol}"
 
-# Location of the runtime directory and ``wxnow.txt`` file.  These are used
-# by ``send_via_wxnow`` when writing the current weather frame.
-PROJECT_ROOT = Path(__file__).resolve().parent
-RUNTIME_DIR = PROJECT_ROOT / "runtime"
-RUNTIME_DIR.mkdir(exist_ok=True)
-WXNOW = RUNTIME_DIR / "wxnow.txt"
 
 
 def send_via_kiss(ax25_frame):
@@ -117,17 +111,4 @@ def send_via_kiss(ax25_frame):
     with socket.create_connection(("127.0.0.1", 8001)) as s:
         s.send(kiss_frame)
 
-
-def send_via_wxnow(frame: str) -> None:
-    """Write an APRS weather frame to ``wxnow.txt``.
-
-    Parameters
-    ----------
-    frame : str
-        The APRS text frame to record.
-    """
-    timestamp = datetime.now(timezone.utc).strftime("%b %d %Y %H:%M\n")
-    with open(WXNOW, "w") as f:
-        f.write(timestamp)
-        f.write(frame + "\n")
 

--- a/tests/test_kiss.py
+++ b/tests/test_kiss.py
@@ -18,6 +18,14 @@ class DummySocket:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
+
+def test_send_via_kiss(monkeypatch):
+    """Verify frames are sent over a socket."""
+    dummy = DummySocket()
+    with patch('socket.create_connection', return_value=dummy):
+        shared.send_via_kiss(b'TEST')
+    assert dummy.sent == b'\xC0\x00TEST\xC0'
+
 class TestKissEscaping(unittest.TestCase):
     def _run_send(self, payload):
         dummy = DummySocket()

--- a/tests/test_wxnow.py
+++ b/tests/test_wxnow.py
@@ -1,9 +1,0 @@
-import shared_functions as shared
-
-
-def test_send_via_wxnow(tmp_path, monkeypatch):
-    dest = tmp_path / "wxnow.txt"
-    monkeypatch.setattr(shared, "WXNOW", dest)
-    shared.send_via_wxnow("TESTFRAME")
-    lines = dest.read_text().splitlines()
-    assert lines[-1] == "TESTFRAME"

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -44,7 +44,7 @@ port = 8080
 path = /data/report
 
 # Ecowitt listener uses the station latitude and longitude from the APRS
-# section to generate the ``wxnow.txt`` position block.
+# section to generate the position block.
 
 [HUBTELEMETRY]
 # Enable or disable the telemetry beacon


### PR DESCRIPTION
## Summary
- remove unused wxnow file logic
- send Ecowitt frames directly via KISS
- drop wxnow test and test socket send in test_kiss
- clean up comment in configuration template

## Testing
- `./tests/runTests.sh` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e79b8fbbc8323939ae696b980ced7