### PR TITLE
Improve missing Direwolf handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,12 @@ def start_direwolf():
     runtime_dir = PROJECT_ROOT / "runtime"
     runtime_dir.mkdir(exist_ok=True)
     direwolf_bin = PROJECT_ROOT / "external" / "direwolf" / "build" / "src" / "direwolf"
+    if not direwolf_bin.exists():
+        logging.error(
+            "Direwolf binary not found at %s. Please run build_external.sh first",
+            direwolf_bin,
+        )
+        return None
     cmd = [str(direwolf_bin), "-c", str(conf), "-l", "direwolf.log"]
     logging.info("Starting Direwolf: %s", " ".join(cmd))
     return subprocess.Popen(cmd)

--- a/tests/test_start_direwolf.py
+++ b/tests/test_start_direwolf.py
@@ -1,0 +1,14 @@
+import logging
+import main
+import config
+
+
+def test_missing_direwolf_logs_error(monkeypatch, tmp_path, caplog):
+    monkeypatch.setattr(main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(config, "load_direwolf_config", lambda: {"enabled": True})
+    # provide template so start_direwolf can copy it
+    (tmp_path / "direwolf.conf.template").write_text("")
+    with caplog.at_level(logging.ERROR):
+        proc = main.start_direwolf()
+    assert proc is None
+    assert any("Direwolf binary not found" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- detect missing Direwolf binary and log a helpful error message
- add unit test for missing Direwolf path

## Testing
- `tests/runTests.sh` *(fails: Could not install pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e7cc4172c8323b955e5ecf982c6ef