### PR TITLE
Add kiss_client start log

### DIFF
--- a/daemons/kiss_client.py
+++ b/daemons/kiss_client.py
@@ -63,4 +63,5 @@ def start():
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
+    log_info("kiss_client thread started")
     return _Server(), thread


### PR DESCRIPTION
## Summary
- log when the kiss_client daemon thread starts

## Testing
- `./tests/runTests.sh` *(fails: Could not install pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e9544958483238a09510d4d41618b