### PR TITLE
Add logger names to utils and modules

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -114,11 +114,11 @@ def ecowitt_to_aprs(p):
 
 
 def log_params(client, params):
-    utils.log_info("Ecowitt upload from %s", client)
+    utils.log_info("Ecowitt upload from %s", client, source=__name__)
     for k in sorted(params):
-        utils.log_info("  %s: %s", k, params[k])
+        utils.log_info("  %s: %s", k, params[k], source=__name__)
     info = ecowitt_to_aprs(params)
-    utils.log_info(info)
+    utils.log_info(info, source=__name__)
     ax25 = utils.build_ax25_frame(_dest, _callsign, _path, info)
     utils.send_via_kiss(ax25)
 
@@ -126,7 +126,12 @@ def log_params(client, params):
 class Handler(BaseHTTPRequestHandler):
     def setup(self):
         super().setup()
-        utils.log_info("Connection from %s:%s", self.client_address[0], self.client_address[1])
+        utils.log_info(
+            "Connection from %s:%s",
+            self.client_address[0],
+            self.client_address[1],
+            source=__name__,
+        )
 
     def _okay(self):
         self.send_response(200)
@@ -164,13 +169,13 @@ def start():
         ``(server, thread)`` if enabled, otherwise ``(None, None)``.
     """
     if not ENABLED:
-        utils.log_info("Ecowitt listener disabled in configuration")
+        utils.log_info("Ecowitt listener disabled in configuration", source=__name__)
         return None, None
 
     server = HTTPServer(("", PORT), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    utils.log_info("Listening on 0.0.0.0:%s%s", PORT, PATH)
+    utils.log_info("Listening on 0.0.0.0:%s%s", PORT, PATH, source=__name__)
     return server, thread
 
 

--- a/daemons/kiss_client.py
+++ b/daemons/kiss_client.py
@@ -38,9 +38,9 @@ def _run():
             try:
                 _socket.send(_escape(frame))
             except Exception:
-                log_exception("Failed to send KISS frame")
+                log_exception("Failed to send KISS frame", source=__name__)
     except Exception:
-        log_exception("kiss_client failed to connect")
+        log_exception("kiss_client failed to connect", source=__name__)
     finally:
         if _socket:
             try:
@@ -58,10 +58,10 @@ class _Server:
 def start():
     """Start the KISS client thread."""
     if not ENABLED:
-        log_info("kiss_client disabled in configuration")
+        log_info("kiss_client disabled in configuration", source=__name__)
         return None, None
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
-    log_info("kiss_client thread started")
+    log_info("kiss_client thread started", source=__name__)
     return _Server(), thread

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 def start_direwolf():
     cfg = config.load_direwolf_config()
     if not cfg.get("enabled", True):
-        log_info("Direwolf disabled in configuration")
+        log_info("Direwolf disabled in configuration", source=__name__)
         return None
     conf = PROJECT_ROOT / "direwolf.conf"
     if not conf.exists():
@@ -29,10 +29,11 @@ def start_direwolf():
         log_error(
             "Direwolf binary not found at %s. Please run build_external.sh first",
             direwolf_bin,
+            source=__name__,
         )
         return None
     cmd = [str(direwolf_bin), "-c", str(conf), "-l", "direwolf.log"]
-    log_info("Starting Direwolf: %s", " ".join(cmd))
+    log_info("Starting Direwolf: %s", " ".join(cmd), source=__name__)
     return subprocess.Popen(cmd)
 
 
@@ -49,7 +50,7 @@ def start_rigctld(rig_id: int, usb_num: int, port: int):
         "-t",
         str(port),
     ]
-    log_info("Starting rigctld: %s", " ".join(cmd))
+    log_info("Starting rigctld: %s", " ".join(cmd), source=__name__)
     return subprocess.Popen(cmd)
 
 
@@ -58,24 +59,24 @@ def start_daemon_modules():
     daemons = []
     for name in config.load_daemon_modules():
         try:
-            log_info("Starting daemon %s", name)
+            log_info("Starting daemon %s", name, source=__name__)
             module = importlib.import_module(name)
             if hasattr(module, "start"):
                 server, thread = module.start()
                 if server:
                     daemons.append((server, thread))
         except Exception as exc:
-            log_exception("Failed to start daemon %s: %s", name, exc)
+            log_exception("Failed to start daemon %s: %s", name, exc, source=__name__)
     return daemons
 
 
 def run_telemetry_module(name: str):
     """Execute a single telemetry module."""
     try:
-        log_info("Running telemetry %s", name)
+        log_info("Running telemetry %s", name, source=__name__)
         subprocess.run([sys.executable, "-m", name])
     except Exception as exc:
-        log_exception("Telemetry module %s failed: %s", name, exc)
+        log_exception("Telemetry module %s failed: %s", name, exc, source=__name__)
 
 
 
@@ -111,7 +112,7 @@ def main():
             rig_cfg.get("port", config.RIGCTLD_PORT),
         )
     else:
-        log_info("rigctld disabled in configuration")
+        log_info("rigctld disabled in configuration", source=__name__)
 
     daemon_instances = start_daemon_modules()
 
@@ -156,7 +157,7 @@ def main():
                 time.sleep(min(1, sleep_left))
                 sleep_left -= 1
     finally:
-        log_info("Shutting down")
+        log_info("Shutting down", source=__name__)
         for server, thread in daemon_instances:
             server.shutdown()
             thread.join()

--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -76,12 +76,12 @@ def main(argv=None):
 
     cfg = config.load_direwolf_config()
     if not cfg.get("enabled", True):
-        utils.log_info("direwolf telemetry disabled in configuration")
+        utils.log_info("direwolf telemetry disabled in configuration", source=__name__)
         sys.exit(0)
 
     metrics = read_metrics()
     if not metrics:
-        utils.log_error("No telemetry metrics found")
+        utils.log_error("No telemetry metrics found", source=__name__)
         sys.exit(1)
 
     callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config()
@@ -89,8 +89,8 @@ def main(argv=None):
     frame = utils.build_ax25_frame(dest, callsign, path, info)
 
     if args.debug:
-        utils.log_info(info)
-        utils.log_info(frame.hex())
+        utils.log_info(info, source=__name__)
+        utils.log_info(frame.hex(), source=__name__)
     else:
         utils.send_via_kiss(frame)
 

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -108,32 +108,32 @@ def main(argv=None):
 
     tele_cfg = config.load_hubtelemetry_config()
     if not tele_cfg.get("enabled", True):
-        utils.log_info("hub_telemetry disabled in configuration")
+        utils.log_info("hub_telemetry disabled in configuration", source=__name__)
         sys.exit(0)
 
     callsign, latitude, longitude, symbol_table, symbol, path, destination, version = config.load_aprs_config()
     if args.debug:
-        utils.log_info("Config Loaded:")
+        utils.log_info("Config Loaded:", source=__name__)
         utils.log_info(
             f"callsign={callsign}, lat={latitude}, lon={longitude}, symbol_table={symbol_table}, symbol={symbol}, path={path}, dest={destination}, version={version}"
-        )
+        , source=__name__)
 
     telemetry = get_laptop_telemetry()
     if args.debug:
-        utils.log_info("Telemetry Collected:")
+        utils.log_info("Telemetry Collected:", source=__name__)
         utils.log_info(
             f"cpuT={telemetry[0]:.1f}, load={telemetry[1]:.0f}, uptime={telemetry[2]}h, mem={telemetry[3]:.0f}%, disk={telemetry[4]:.0f}%, rx={telemetry[5]}MB, tx={telemetry[6]}MB"
-        )
+        , source=__name__)
 
     info = build_aprs_info(latitude, longitude, symbol_table, symbol, version, *telemetry)
     if args.debug:
-        utils.log_info("APRS Info Field:")
-        utils.log_info(info)
+        utils.log_info("APRS Info Field:", source=__name__)
+        utils.log_info(info, source=__name__)
 
     ax25_frame = utils.build_ax25_frame(destination, callsign, path, info)
     if args.debug:
-        utils.log_info("AX25 Frame Built:")
-        utils.log_info(ax25_frame.hex())
+        utils.log_info("AX25 Frame Built:", source=__name__)
+        utils.log_info(ax25_frame.hex(), source=__name__)
 
     if not args.debug:
         utils.send_via_kiss(ax25_frame)

--- a/utils.py
+++ b/utils.py
@@ -21,27 +21,38 @@ def setup_logging(level=logging.INFO, use_utc=False):
         logging.Formatter.converter = time.gmtime
     logging.basicConfig(
         level=level,
-        format="[%(asctime)s] %(message)s",
+        format="[%(asctime)s] %(name)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
 
-def log_info(message, *args, **kwargs):
-    """Log an informational message via the root logger."""
+def log_info(message, *args, source=None, **kwargs):
+    """Log an informational message.
 
-    logging.info(message, *args, **kwargs)
+    Parameters
+    ----------
+    message : str
+        The log message.
+    source : str, optional
+        Name of the logger to use. If omitted, the root logger is used.
+    """
+
+    logger = logging.getLogger(source) if source else logging.getLogger()
+    logger.info(message, *args, **kwargs)
 
 
-def log_error(message, *args, **kwargs):
-    """Log an error message via the root logger."""
+def log_error(message, *args, source=None, **kwargs):
+    """Log an error message."""
 
-    logging.error(message, *args, **kwargs)
+    logger = logging.getLogger(source) if source else logging.getLogger()
+    logger.error(message, *args, **kwargs)
 
 
-def log_exception(message, *args, **kwargs):
-    """Log an exception with traceback via the root logger."""
+def log_exception(message, *args, source=None, **kwargs):
+    """Log an exception with traceback."""
 
-    logging.exception(message, *args, **kwargs)
+    logger = logging.getLogger(source) if source else logging.getLogger()
+    logger.exception(message, *args, **kwargs)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include `%(name)s` in log formatting
- allow `log_info`, `log_error`, and `log_exception` to target named loggers
- pass module names when logging from daemons and telemetry scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_685e963c51d483239a52cb103e4b1430