### PR TITLE
Fix default start of kiss_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ The files contains configuration settings for the ``Direwolf TNC`` and **kf6ufo-
 ``Direwolf`` can be used by itself to handle PTT on the radio, or ``rigctld`` is included
 for more options in handling PTT.
 If ``rigctld`` is enabled, be sure that the ``Direwolf`` port for ``rigctld`` is the same
-as is configured for ``rigctld`` in ``wx-helios,conf``
+as is configured for ``rigctld`` in ``wx-helios,conf``.
+
+Background services are controlled in the ``[DAEMONS]`` section.  By default
+both the Ecowitt listener and the ``kiss_client`` daemon are launched.  Removing
+``daemons.kiss_client`` from the module list disables the persistent KISS
+connection and causes every packet send to open a new TCP connection.
 
 Telemetry modules can be scheduled individually using cron syntax.  
 

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -53,7 +53,7 @@ enabled = yes
 [DAEMONS]
 # Comma-separated list of daemon modules to launch
 enabled = yes
-modules = daemons.ecowitt_listener
+modules = daemons.ecowitt_listener, daemons.kiss_client
 
 [TELEMETRY]
 # Comma-separated list of telemetry modules to run periodically


### PR DESCRIPTION
## Summary
- start kiss_client with other daemons by default
- document daemon list in README

## Testing
- `tests/runTests.sh` *(fails: Could not install pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685e9914ae7c83238403d940fd3aa55c