### PR TITLE
Fix kiss queue detection

### DIFF
--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -11,7 +11,6 @@ def test_send_via_kiss_uses_daemon_queue(monkeypatch):
 
     monkeypatch.setattr(kc, "FRAME_QUEUE", DummyQueue())
     monkeypatch.setattr(kc, "ENABLED", True)
-    monkeypatch.setattr(kc, "_socket", object())
 
     def fail(*a, **k):
         raise AssertionError("socket should not be used")

--- a/utils.py
+++ b/utils.py
@@ -127,6 +127,9 @@ def decimal_to_aprs(lat: float, lon: float, symbol_table: str, symbol: str) -> s
 def send_via_kiss(ax25_frame):
     """Send a frame via a KISS TCP connection on localhost.
 
+    If the ``kiss_client`` daemon is active, the frame is queued for that
+    persistent connection instead of opening a new socket each time.
+
     Parameters
     ----------
     ax25_frame : bytes or bytearray
@@ -139,10 +142,8 @@ def send_via_kiss(ax25_frame):
     """
     try:
         from daemons import kiss_client
-        if (
-            getattr(kiss_client, "ENABLED", False)
-            and hasattr(kiss_client, "FRAME_QUEUE")
-            and getattr(kiss_client, "_socket", None) is not None
+        if getattr(kiss_client, "ENABLED", False) and hasattr(
+            kiss_client, "FRAME_QUEUE"
         ):
             kiss_client.FRAME_QUEUE.put(ax25_frame)
             return


### PR DESCRIPTION
## Summary
- improve `utils.send_via_kiss` so it queues frames if the kiss daemon is enabled regardless of `_socket`
- adjust test for new logic

## Testing
- `pytest tests/test_kiss.py tests/test_kiss_client_daemon.py tests/test_direwolf_telemetry.py -q`
- `pytest -k 'not main_daemons and not main_schedule and not start_direwolf' -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_685eacd42c4c83238609f610cd0314f2