### PR TITLE
Implement configurable KISS client host and port

### DIFF
--- a/config.py
+++ b/config.py
@@ -103,9 +103,13 @@ def load_kiss_client_config():
     cfg = _get_config()
     section = "KISS_CLIENT"
     if section not in cfg:
-        return {"enabled": False}
+        return {"enabled": False, "host": "127.0.0.1", "port": 8001}
     kc = cfg[section]
-    return {"enabled": kc.getboolean("enabled", True)}
+    return {
+        "enabled": kc.getboolean("enabled", True),
+        "host": kc.get("host", "127.0.0.1"),
+        "port": int(kc.get("port", 8001)),
+    }
 
 
 def load_rig_config():

--- a/daemons/kiss_client.py
+++ b/daemons/kiss_client.py
@@ -15,6 +15,8 @@ LOG_SOURCE = (
 
 cfg = config.load_kiss_client_config()
 ENABLED = cfg.get("enabled", False)
+HOST = cfg.get("host", "127.0.0.1")
+PORT = cfg.get("port", 8001)
 
 FRAME_QUEUE = queue.Queue()
 _stop = threading.Event()
@@ -37,7 +39,7 @@ def _run():
     """Open a single KISS TCP connection and send queued frames."""
     global _socket
     try:
-        _socket = socket.create_connection(("127.0.0.1", 8001))
+        _socket = socket.create_connection((HOST, PORT))
         _socket.settimeout(0.2)
     except Exception:
         log_exception("kiss_client failed to connect", source=LOG_SOURCE)

--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -21,3 +21,33 @@ def test_send_via_kiss_uses_daemon_queue(monkeypatch):
     shared.send_via_kiss(frame)
 
     assert items == [frame]
+
+
+def test_kiss_client_connects_to_configured_host_port(monkeypatch):
+    """Verify the daemon connects using configured host and port."""
+
+    captured = {}
+
+    class DummySocket:
+        def settimeout(self, t):
+            pass
+
+        def close(self):
+            pass
+
+        def send(self, data):
+            pass
+
+    def fake_create(addr):
+        captured["addr"] = addr
+        return DummySocket()
+
+    monkeypatch.setattr(kc.socket, "create_connection", fake_create)
+    monkeypatch.setattr(kc, "HOST", "5.6.7.8")
+    monkeypatch.setattr(kc, "PORT", 7000)
+    kc.FRAME_QUEUE = kc.queue.Queue()
+    kc.FRAME_QUEUE.put(None)
+    kc._stop.clear()
+    kc._run()
+
+    assert captured.get("addr") == ("5.6.7.8", 7000)

--- a/utils.py
+++ b/utils.py
@@ -160,7 +160,11 @@ def send_via_kiss(ax25_frame):
             escaped.append(b)
 
     kiss_frame = b"\xC0\x00" + bytes(escaped) + b"\xC0"
-    with socket.create_connection(("127.0.0.1", 8001)) as s:
+    from config import load_kiss_client_config
+    cfg = load_kiss_client_config()
+    host = cfg.get("host", "127.0.0.1")
+    port = cfg.get("port", 8001)
+    with socket.create_connection((host, port)) as s:
         s.send(kiss_frame)
 
 

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -82,3 +82,9 @@ port = 4534
 [KISS_CLIENT]
 # Enable or disable the background KISS client
 enabled = yes
+
+# Host running the KISS TCP server
+host = 127.0.0.1
+
+# TCP port for the KISS server
+port = 8001


### PR DESCRIPTION
## Summary
- add `host` and `port` options to the `[KISS_CLIENT]` config section
- parse host/port defaults in `config.load_kiss_client_config`
- use configured host and port in `kiss_client` daemon
- use configured host and port in `utils.send_via_kiss`
- extend KISS tests to check host/port behaviour

## Testing
- `tests/runTests.sh` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685eb43031408323be954b841369c723