### PR TITLE
Update KISS daemon test

### DIFF
--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -73,6 +73,7 @@ def test_subprocess_can_queue_frame(monkeypatch):
     monkeypatch.setattr(kc.socket, "create_connection", lambda a: DummySocket())
     monkeypatch.setattr(kc, "HOST", "1.2.3.4")
     monkeypatch.setattr(kc, "PORT", 9000)
+    monkeypatch.setattr(kc, "ENABLED", True)
 
     server, thread = kc.start()
     try:


### PR DESCRIPTION
## Summary
- make sure the KISS client daemon is enabled in `test_subprocess_can_queue_frame`

## Testing
- `pytest -q` *(fails: test_subprocess_can_queue_frame)*

------
https://chatgpt.com/codex/tasks/task_e_685ecbb008508323974f5a98aba7dc56