### PR TITLE
Fix KISS client queue manager

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -161,7 +161,19 @@ def send_via_kiss(ax25_frame):
             class _QueueManager(SyncManager):
                 pass
 
-            _QueueManager.register("get_frame_queue")
+            _QUEUE_METHODS = (
+                "empty",
+                "full",
+                "get",
+                "get_nowait",
+                "join",
+                "put",
+                "put_nowait",
+                "qsize",
+                "task_done",
+            )
+
+            _QueueManager.register("get_frame_queue", exposed=_QUEUE_METHODS)
             mgr = _QueueManager(address=(host, int(port)), authkey=authkey)
             mgr.connect()
             q = mgr.get_frame_queue()


### PR DESCRIPTION
## Summary
- ensure multiprocessing manager shares queue correctly
- reset stop flag when starting KISS client
- register queue methods in subprocess helper

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ed05d59148323a50a3f38c5447307