### PR TITLE
Fix subprocess test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ runtime/
 *.swo
 *.bak
 *.tmp
+.venv/
 

--- a/tests/test_kiss_client_daemon.py
+++ b/tests/test_kiss_client_daemon.py
@@ -78,7 +78,11 @@ def test_subprocess_can_queue_frame(monkeypatch):
     server, thread = kc.start()
     try:
         cmd = [sys.executable, "-c", "import utils; utils.send_via_kiss(b'HI')"]
-        subprocess.run(cmd, env=os.environ.copy(), check=True)
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(
+            [os.path.dirname(os.path.dirname(__file__)), env.get("PYTHONPATH", "")]
+        )
+        subprocess.run(cmd, env=env, check=True)
         time.sleep(0.1)
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- fix `test_subprocess_can_queue_frame` by exporting PYTHONPATH for the subprocess
- ignore local `.venv` folder

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ed955c7c48323850b81f7d2450c90