### PR TITLE
Ensure Direwolf logs resolve from repo root

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,8 @@ def start_direwolf():
             source=LOG_SOURCE,
         )
         return None
-    cmd = [str(direwolf_bin), "-c", str(conf), "-l", "direwolf.log"]
+    log_file = PROJECT_ROOT / "direwolf.log"
+    cmd = [str(direwolf_bin), "-c", str(conf), "-l", str(log_file)]
     log_info("Starting Direwolf: %s", " ".join(cmd), source=LOG_SOURCE)
     return subprocess.Popen(cmd)
 

--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,6 @@ fi
 # Activate the environment so any subprocesses use its tools
 source "$VENV_DIR/bin/activate"
 
+cd "$SCRIPT_DIR"
 exec python "$SCRIPT_DIR/main.py" "$@"
 


### PR DESCRIPTION
## Summary
- run from repo root in `run.sh`
- always write `direwolf.log` to absolute path

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ee549851483238594f3842032f1d1