### PR TITLE
Switch direwolf to single log file

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def start_direwolf():
         )
         return None
     log_file = PROJECT_ROOT / "direwolf.log"
-    cmd = [str(direwolf_bin), "-c", str(conf), "-l", str(log_file)]
+    cmd = [str(direwolf_bin), "-c", str(conf), "-L", str(log_file)]
     log_info("Starting Direwolf: %s", " ".join(cmd), source=LOG_SOURCE)
     return subprocess.Popen(cmd)
 

--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -31,23 +31,8 @@ def parse_metrics(line):
 
 
 def read_metrics(path=LOG_PATH):
-    """Return the most recent set of metrics from ``direwolf.log``.
-
-    ``path`` may point directly to a log file or a directory containing
-    rotated log files.  When a directory is provided, the newest ``*.log``
-    file inside the directory is used.
-    """
+    """Return the most recent set of metrics from ``direwolf.log``."""
     p = Path(path)
-    if p.is_dir():
-        log_files = sorted(
-            [f for f in p.glob("*.log") if f.is_file()],
-            key=lambda f: f.stat().st_mtime,
-            reverse=True,
-        )
-        if not log_files:
-            return None
-        p = log_files[0]
-
     try:
         with p.open("r") as f:
             lines = f.readlines()

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -14,6 +14,15 @@ def test_parse_metrics():
     assert result == {"busy": 12.5, "rcvq": 3, "sendq": 2}
 
 
+def test_read_metrics_file(tmp_path):
+    log_file = tmp_path / "direwolf.log"
+    log_file.write_text(
+        "noise\nT: busy=12.5% cd=0 rcvq=4(0.0) sendq=3(0.0)\nmore\n"
+    )
+    result = dw.read_metrics(log_file)
+    assert result == {"busy": 12.5, "rcvq": 4, "sendq": 3}
+
+
 def test_kiss_frame_generation(monkeypatch):
     metrics = {"busy": 1.0, "rcvq": 2, "sendq": 3}
 


### PR DESCRIPTION
## Summary
- specify direwolf logfile with `-L` instead of daily logs
- simplify `direwolf_telemetry.read_metrics` for single log file
- test reading metrics from a direct log file

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685eeaf06f6c83238c23fbd734a9659d