### PR TITLE
Enable direwolf packet debug

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ def start_direwolf():
         )
         return None
     log_file = PROJECT_ROOT / "direwolf.log"
-    cmd = [str(direwolf_bin), "-c", str(conf), "-L", str(log_file)]
+    cmd = [str(direwolf_bin), "-dttt", "-c", str(conf), "-L", str(log_file)]
     log_info("Starting Direwolf: %s", " ".join(cmd), source=LOG_SOURCE)
     return subprocess.Popen(cmd)
 


### PR DESCRIPTION
## Summary
- enable Direwolf packet tracking by starting it with `-dttt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ef0f01ea48323bf31ae31a990a8ab