### PR TITLE
Fix wind speed field format in APRS weather messages

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -87,7 +87,7 @@ def clamp(val, lo, hi):
 def ecowitt_to_aprs(p):
     # wind
     wd = clamp(int(float(p["winddir"])), 0, 360)
-    ws = clamp(int(float(p["windspeedmph"])), 0, 99)
+    ws = clamp(int(float(p["windspeedmph"])), 0, 999)
     wg = clamp(int(float(p["windgustmph"])), 0, 999)
 
     # temperature
@@ -112,7 +112,7 @@ def ecowitt_to_aprs(p):
     # timestamp + assemble
     ts = datetime.now(timezone.utc).strftime("%d%H%M")
     return (f"@{ts}z{POS_BLOCK}"
-            f"{wd:03d}/{ws:02d}g{wg:03d}"
+            f"{wd:03d}/{ws:03d}g{wg:03d}"
             f"{t_field}"
             f"r{rRRR:03d}p{pPPP:03d}P{PQQQ:03d}"
             f"h{rh:02d}b{bp:05d}")

--- a/tests/test_ecowitt.py
+++ b/tests/test_ecowitt.py
@@ -35,6 +35,30 @@ def test_temperature_field(temp, expected):
     frame = mod.ecowitt_to_aprs(params)
     assert expected in frame
 
+
+@pytest.mark.parametrize("speed,expected", [
+    (0, "000"),
+    (5, "005"),
+    (123, "123"),
+    (500, "500"),
+])
+def test_wind_speed_field(speed, expected):
+    mod = load_module()
+    mod.update_rain_24h = lambda p: 0
+    params = {
+        "winddir": "0",
+        "windspeedmph": str(speed),
+        "windgustmph": "0",
+        "tempf": "0",
+        "hourlyrainin": "0",
+        "eventrainin": "0",
+        "humidity": "50",
+        "baromrelin": "30",
+        "dateutc": "2020-01-01 00:00:00",
+    }
+    frame = mod.ecowitt_to_aprs(params)
+    assert f"/{expected}" in frame
+
 def test_update_rain_24h_accumulation_and_cleanup():
     """Verify 24‑h totals over a simulated 48‑h period."""
     mod = load_module()


### PR DESCRIPTION
## Summary
- fix APRS weather string to use 3-digit wind speed field
- allow wind speeds up to 999 mph
- add tests verifying wind speed field formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0d48a6048323af9ca019add07369