### PR TITLE
Handle missing Direwolf telemetry gracefully

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -85,8 +85,10 @@ def main(argv=None):
 
     metrics = read_metrics()
     if not metrics:
-        utils.log_error("No telemetry metrics found", source=LOG_SOURCE)
-        sys.exit(1)
+        utils.log_info(
+            "No telemetry metrics found, sending zeros", source=LOG_SOURCE
+        )
+        metrics = {}
 
     callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config()
     info = build_aprs_info(lat, lon, table, symbol, ver, metrics)

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -51,3 +51,27 @@ def test_kiss_frame_generation(monkeypatch):
     expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected
+
+
+def test_zero_frame_when_no_metrics(monkeypatch):
+    monkeypatch.setattr(config, "load_direwolf_config", lambda: {"enabled": True})
+    monkeypatch.setattr(dw, "read_metrics", lambda path=None: None)
+    monkeypatch.setattr(
+        config,
+        "load_aprs_config",
+        lambda: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
+    )
+
+    sent = []
+
+    def fake_send(frame):
+        sent.append(frame)
+
+    monkeypatch.setattr(shared, "send_via_kiss", fake_send)
+
+    dw.main([])
+
+    info = dw.build_aprs_info(10.0, -100.0, "/", "Y", "v1", {})
+    expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
+
+    assert sent and sent[0] == expected


### PR DESCRIPTION
## Summary
- if Direwolf metrics are missing, log the condition and transmit a zeroed frame
- add regression test for zero-telemetry case

## Testing
- `./tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685faaaf2b488323a633eea7e6265d94