### PR TITLE
Add module-level APRS configuration

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -26,17 +26,17 @@ try:
         _lon_dd,
         _symbol_table,
         _symbol,
-        _path,
+        _digipeater_path,
         _dest,
         _version,
-    ) = config.load_aprs_config()
+    ) = config.load_aprs_config("ECOWITT")
 except Exception:
     _callsign = "NOCALL"
     _lat_dd = 0.0
     _lon_dd = 0.0
     _symbol_table = "/"
     _symbol = "-"
-    _path = []
+    _digipeater_path = []
     _dest = "APZ001"
     _version = ""
 
@@ -127,7 +127,7 @@ def log_params(client, params):
         utils.log_info("  %s: %s", k, params[k], source=LOG_SOURCE)
     info = ecowitt_to_aprs(params)
     utils.log_info(info, source=LOG_SOURCE)
-    ax25 = utils.build_ax25_frame(_dest, _callsign, _path, info)
+    ax25 = utils.build_ax25_frame(_dest, _callsign, _digipeater_path, info)
     utils.send_via_kiss(ax25)
 
 

--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -90,7 +90,7 @@ def main(argv=None):
         )
         metrics = {}
 
-    callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config()
+    callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config("DIREWOLF_TELEMETRY")
     info = build_aprs_info(lat, lon, table, symbol, ver, metrics)
     frame = utils.build_ax25_frame(dest, callsign, path, info)
 

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -116,7 +116,7 @@ def main(argv=None):
         utils.log_info("hub_telemetry disabled in configuration", source=LOG_SOURCE)
         sys.exit(0)
 
-    callsign, latitude, longitude, symbol_table, symbol, path, destination, version = config.load_aprs_config()
+    callsign, latitude, longitude, symbol_table, symbol, path, destination, version = config.load_aprs_config("HUBTELEMETRY")
     if args.debug:
         utils.log_info("Config Loaded:", source=LOG_SOURCE)
         utils.log_info(

--- a/tests/test_aprs_module_config.py
+++ b/tests/test_aprs_module_config.py
@@ -1,0 +1,38 @@
+import config
+
+
+def write_config(tmp_path, text, monkeypatch):
+    path = tmp_path / "wx-helios.conf"
+    path.write_text(text)
+    monkeypatch.setattr(config, "CONFIG_PATH", path)
+    config._config = None
+    return path
+
+
+def test_aprs_module_override(tmp_path, monkeypatch):
+    cfg_text = """
+[APRS]
+callsign = N0CALL-9
+latitude = 1
+longitude = 2
+symbol_table = primary
+symbol = T
+path = W1-1
+
+[ECOWITT]
+symbol_table = secondary
+symbol = W
+digipeater_path = W2-2,W3-3
+"""
+    write_config(tmp_path, cfg_text, monkeypatch)
+    # Default section
+    base = config.load_aprs_config()
+    assert base[3] == "/"
+    assert base[4] == "T"
+    assert base[5] == ["W1-1"]
+    # Module override
+    mod = config.load_aprs_config("ECOWITT")
+    assert mod[3] == "\\"
+    assert mod[4] == "W"
+    assert mod[5] == ["W2-2", "W3-3"]
+

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -35,7 +35,7 @@ def test_kiss_frame_generation(monkeypatch):
     monkeypatch.setattr(
         config,
         "load_aprs_config",
-        lambda: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
+        lambda *a, **k: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
     )
 
     sent = []
@@ -59,7 +59,7 @@ def test_zero_frame_when_no_metrics(monkeypatch):
     monkeypatch.setattr(
         config,
         "load_aprs_config",
-        lambda: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
+        lambda *a, **k: ("SRC-1", 10.0, -100.0, "/", "Y", ["WIDE1-1"], "DEST", "v1"),
     )
 
     sent = []

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -23,6 +23,11 @@ symbol = _
 # Digipeater path
 path = WIDE1-1,WIDE2-1
 
+# Individual modules can override ``symbol_table``, ``symbol`` and ``path``
+# using the same option names in their own sections. For example the
+# ``[ECOWITT]`` section below can specify ``symbol`` and ``digipeater_path``
+# for weather packets.
+
 # APRS destination field
 # Use APZ001 for custom experimental software
 destination = APZ001
@@ -43,12 +48,26 @@ port = 8080
 # URL path for uploads
 path = /data/report
 
+# Weather packets can use a different APRS symbol or digipeater path
+symbol_table = primary
+symbol = _
+digipeater_path = WIDE2-2
+
 # Ecowitt listener uses the station latitude and longitude from the APRS
 # section to generate the position block.
 
 [HUBTELEMETRY]
 # Enable or disable the telemetry beacon
 enabled = yes
+symbol_table = primary
+symbol = _
+digipeater_path = WIDE1-1,WIDE2-1
+
+[DIREWOLF_TELEMETRY]
+# Options for telemetry generated from Direwolf logs
+symbol_table = primary
+symbol = _
+digipeater_path = WIDE1-1,WIDE2-1
 
 [DAEMONS]
 # Comma-separated list of daemon modules to launch


### PR DESCRIPTION
## Summary
- support per-module APRS symbol settings via new `load_aprs_config(section)` helper
- update Ecowitt listener and telemetry modules to request module-specific config
- document new options in `wx-helios.conf.template`
- test module overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686096704ecc8323b555411ebb907344