### PR TITLE
Implement APRS telemetry packets

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -61,14 +61,16 @@ def read_metrics(path=LOG_PATH):
     return None
 
 
-def build_aprs_info(lat, lon, table, symbol, version, metrics):
-    pos = utils.decimal_to_aprs(lat, lon, table, symbol)
-    comment = (
-        f"dw_busy={metrics.get('busy', 0):.1f} "
-        f"dw_rcvq={metrics.get('rcvq', 0)} "
-        f"dw_sendq={metrics.get('sendq', 0)} ver={version}"
-    )
-    return pos + comment
+def build_aprs_info(lat, lon, table, symbol, version, metrics, seq=0):
+    """Build an APRS telemetry packet for Direwolf metrics."""
+
+    busy = metrics.get("busy", 0.0) * 10
+    rcvq = metrics.get("rcvq", 0)
+    sendq = metrics.get("sendq", 0)
+
+    analog = [busy, rcvq, sendq]
+    comment = f"ver={version}"
+    return utils.build_aprs_telemetry(seq, analog=analog, comment=comment)
 
 
 def main(argv=None):

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -62,44 +62,23 @@ def build_aprs_info(
     disk_percent,
     net_rx_mb,
     net_tx_mb,
+    seq=0,
 ):
-    """Create the APRS information field from telemetry values.
+    """Create an APRS telemetry packet from system metrics."""
 
-    Parameters
-    ----------
-    lat, lon : float
-        Position in decimal degrees.
-    symbol_table : str
-        Symbol table identifier.
-    symbol : str
-        APRS map symbol.
-    version : str
-        Beacon software version string.
-    cpu_temp : float
-        CPU temperature in Celsius.
-    cpu_load : float
-        CPU utilisation percentage.
-    uptime_hours : int
-        System uptime in hours.
-    mem_percent : float
-        Memory usage percentage.
-    disk_percent : float
-        Disk usage percentage.
-    net_rx_mb, net_tx_mb : int
-        Network usage counters in megabytes.
+    analog = [
+        cpu_temp,
+        cpu_load,
+        uptime_hours,
+        net_rx_mb,
+        net_tx_mb,
+    ]
 
-    Returns
-    -------
-    str
-        APRS information field string.
-    """
-    position = utils.decimal_to_aprs(lat, lon, symbol_table, symbol)
-    comment = (
-        f"cpuT={cpu_temp:.1f} load={cpu_load:.0f} upt={uptime_hours}h "
-        f"mem={mem_percent:.0f} disk={disk_percent:.0f} "
-        f"rx={net_rx_mb} tx={net_tx_mb} ver={version}"
-    )
-    return position + comment
+    disk_low = disk_percent >= 90
+    mem_low = mem_percent >= 90
+
+    comment = f"ver={version}"
+    return utils.build_aprs_telemetry(seq, analog=analog, digital=[disk_low, mem_low], comment=comment)
 
 
 # Main logic

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -51,6 +51,7 @@ def test_kiss_frame_generation(monkeypatch):
     expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected
+    assert info == "T#000,010,002,003,000,000,00000000 ver=v1"
 
 
 def test_zero_frame_when_no_metrics(monkeypatch):
@@ -75,3 +76,4 @@ def test_zero_frame_when_no_metrics(monkeypatch):
     expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected
+    assert info == "T#000,000,000,000,000,000,00000000 ver=v1"

--- a/tests/test_hub_telemetry.py
+++ b/tests/test_hub_telemetry.py
@@ -1,0 +1,28 @@
+import pytest
+pytest.importorskip("psutil")
+
+import telemetry.hub_telemetry as hub
+import utils as shared
+import config
+
+
+def test_hub_telemetry_frame(monkeypatch):
+    tele = (25.2, 52.0, 3, 91.0, 40.0, 7, 9)
+    monkeypatch.setattr(hub, "get_laptop_telemetry", lambda: tele)
+    monkeypatch.setattr(config, "load_hubtelemetry_config", lambda: {"enabled": True})
+    monkeypatch.setattr(
+        config,
+        "load_aprs_config",
+        lambda *a, **k: ("SRC-1", 0.0, 0.0, "/", "T", ["WIDE"], "DEST", "v2"),
+    )
+
+    sent = []
+    monkeypatch.setattr(shared, "send_via_kiss", lambda frame: sent.append(frame))
+
+    hub.main([])
+
+    info = hub.build_aprs_info(0.0, 0.0, "/", "T", "v2", *tele)
+    expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE"], info)
+
+    assert sent and sent[0] == expected
+    assert info == "T#000,025,052,003,007,009,01000000 ver=v2"

--- a/utils.py
+++ b/utils.py
@@ -125,6 +125,38 @@ def decimal_to_aprs(lat: float, lon: float, symbol_table: str, symbol: str) -> s
     return f"!{lat_str}{symbol_table}{lon_str}{symbol}"
 
 
+def build_aprs_telemetry(seq: int, analog=None, digital=None, comment: str | None = None) -> str:
+    """Return an APRS telemetry packet string.
+
+    Parameters
+    ----------
+    seq : int
+        Sequence number (0-999).
+    analog : list[float] | None
+        Up to five analog values.
+    digital : list[bool] | None
+        Up to eight digital flags.
+    comment : str | None
+        Optional comment appended after the data.
+    """
+
+    analog = analog or []
+    digital = digital or []
+
+    a_vals = list(analog)[:5]
+    a_vals += [0] * (5 - len(a_vals))
+    a_formatted = [f"{int(round(max(0, min(999, v)))):03d}" for v in a_vals]
+
+    d_vals = list(digital)[:8]
+    d_vals += [0] * (8 - len(d_vals))
+    d_bits = "".join("1" if bool(v) else "0" for v in d_vals)
+
+    info = f"T#{seq:03d}," + ",".join(a_formatted) + f",{d_bits}"
+    if comment:
+        info += f" {comment}"
+    return info
+
+
 
 def send_via_kiss(ax25_frame):
     """Send a frame via a KISS TCP connection on localhost.


### PR DESCRIPTION
## Summary
- support APRS telemetry packet creation via new helper `utils.build_aprs_telemetry`
- generate telemetry packets in `direwolf_telemetry` and `hub_telemetry`
- add tests for telemetry packet format

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68610a4d08a4832398266b746d16b8aa