### PR TITLE
Add APRS telemetry definition beacon

### DIFF
--- a/telemetry/telemetry_defs.py
+++ b/telemetry/telemetry_defs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Transmit APRS telemetry definition messages."""
+import argparse
+import logging
+from pathlib import Path
+
+import config
+import utils
+
+LOG_SOURCE = f"{__package__}.{Path(__file__).stem}" if __package__ else Path(__file__).stem
+
+
+def _build_def_packets(names, units, bits):
+    names = (list(names) + [""] * 5)[:5]
+    units = (list(units) + [""] * 5)[:5]
+    bits = (list(bits) + [""] * 8)[:8]
+
+    parm = "PARM." + ",".join(names)
+    unit = "UNIT." + ",".join(units + bits)
+    eqns = "EQNS." + ",".join(["0","1","0"] * 5)
+    bits_line = "BITS." + ",".join(bits)
+    return [parm, unit, eqns, bits_line]
+
+
+def hub_definitions():
+    names = ["cpuT", "cpuLoad", "uptime", "rxMB", "txMB"]
+    units = ["C", "%", "h", "MB", "MB"]
+    bits = ["diskLow", "memLow"]
+    return _build_def_packets(names, units, bits)
+
+
+def direwolf_definitions():
+    names = ["busy", "rcvq", "sendq"]
+    units = ["%", "", ""]
+    bits = []
+    return _build_def_packets(names, units, bits)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Telemetry definition beacon")
+    parser.add_argument("--debug", action="store_true", help="Enable debug mode")
+    args = parser.parse_args(argv)
+
+    utils.setup_logging(level=logging.DEBUG if args.debug else logging.INFO)
+
+    frames = []
+    if config.load_hubtelemetry_config().get("enabled", True):
+        defs = hub_definitions()
+        callsign, lat, lon, table, sym, path, dest, ver = config.load_aprs_config("HUBTELEMETRY")
+        for info in defs:
+            frame = utils.build_ax25_frame(dest, callsign, path, info)
+            frames.append(frame)
+
+    if config.load_direwolf_config().get("enabled", True):
+        defs = direwolf_definitions()
+        callsign, lat, lon, table, sym, path, dest, ver = config.load_aprs_config("DIREWOLF_TELEMETRY")
+        for info in defs:
+            frame = utils.build_ax25_frame(dest, callsign, path, info)
+            frames.append(frame)
+
+    for frame in frames:
+        if args.debug:
+            utils.log_info(frame.hex(), source=LOG_SOURCE)
+        else:
+            utils.send_via_kiss(frame)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_telemetry_defs.py
+++ b/tests/test_telemetry_defs.py
@@ -1,0 +1,23 @@
+import telemetry.telemetry_defs as defs
+import utils as shared
+import config
+
+
+def test_def_frames(monkeypatch):
+    monkeypatch.setattr(config, "load_hubtelemetry_config", lambda: {"enabled": True})
+    monkeypatch.setattr(config, "load_direwolf_config", lambda: {"enabled": True})
+
+    def fake_aprs(section=None):
+        return ("SRC-1", 0.0, 0.0, "/", "T", ["W"], "DEST", "v")
+
+    monkeypatch.setattr(config, "load_aprs_config", fake_aprs)
+
+    sent = []
+    monkeypatch.setattr(shared, "send_via_kiss", lambda frame: sent.append(frame))
+
+    defs.main([])
+
+    infos = defs.hub_definitions() + defs.direwolf_definitions()
+    expected = [shared.build_ax25_frame("DEST", "SRC-1", ["W"], info) for info in infos]
+
+    assert sent == expected

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -77,7 +77,7 @@ modules = daemons.ecowitt_listener, daemons.kiss_client
 [TELEMETRY]
 # Comma-separated list of telemetry modules to run periodically
 enabled = yes
-modules = telemetry.hub_telemetry, telemetry.direwolf_telemetry
+modules = telemetry.hub_telemetry, telemetry.direwolf_telemetry, telemetry.telemetry_defs
 
 [TELEMETRY_SCHEDULES]
 # Cron expressions for individual telemetry modules
@@ -85,6 +85,8 @@ modules = telemetry.hub_telemetry, telemetry.direwolf_telemetry
 telemetry.hub_telemetry = 0 * * * *
 # Example: poll Dire Wolf telemetry every 5 minutes
 telemetry.direwolf_telemetry = */5 * * * *
+# Transmit telemetry definitions every 6 hours
+telemetry.telemetry_defs = 0 */6 * * *
 # Example: run another module every 15 minutes
 #other.module = */15 * * * *
 


### PR DESCRIPTION
## Summary
- add `telemetry.telemetry_defs` module to send PARM/UNIT/EQNS/BITS packets
- schedule telemetry definition beacon every 6 hours
- test new telemetry definition module

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686110fd631883239dbb9d03a56fdba1