### PR TITLE
Fix Direwolf telemetry definition frames

### DIFF
--- a/telemetry/telemetry_defs.py
+++ b/telemetry/telemetry_defs.py
@@ -15,10 +15,13 @@ def _build_def_packets(names, units, bits):
     units = (list(units) + [""] * 5)[:5]
     bits = (list(bits) + [""] * 8)[:8]
 
-    parm = "PARM." + ",".join(names)
-    unit = "UNIT." + ",".join(units + bits)
-    eqns = "EQNS." + ",".join(["0","1","0"] * 5)
-    bits_line = "BITS." + ",".join(bits)
+    # Definition packets should be sent as APRS messages. Prefix each
+    # payload with a colon so the first character is the ":" data type
+    # indicator recognized by digipeaters and TNC software.
+    parm = ":PARM." + ",".join(names)
+    unit = ":UNIT." + ",".join(units + bits)
+    eqns = ":EQNS." + ",".join(["0", "1", "0"] * 5)
+    bits_line = ":BITS." + ",".join(bits)
     return [parm, unit, eqns, bits_line]
 
 

--- a/tests/test_telemetry_defs.py
+++ b/tests/test_telemetry_defs.py
@@ -19,5 +19,6 @@ def test_def_frames(monkeypatch):
 
     infos = defs.hub_definitions() + defs.direwolf_definitions()
     expected = [shared.build_ax25_frame("DEST", "SRC-1", ["W"], info) for info in infos]
-
     assert sent == expected
+    for info in infos:
+        assert info.startswith(":")


### PR DESCRIPTION
## Summary
- prefix telemetry definition packets with `:` so digipeaters recognize the type
- ensure the test suite validates the colon prefix

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611e36caf88323bbe2af48379022f4