### PR TITLE
Fix telemetry definitions format

### DIFF
--- a/tests/test_telemetry_defs.py
+++ b/tests/test_telemetry_defs.py
@@ -17,7 +17,7 @@ def test_def_frames(monkeypatch):
 
     defs.main([])
 
-    infos = defs.hub_definitions() + defs.direwolf_definitions()
+    infos = defs.hub_definitions("DEST") + defs.direwolf_definitions("DEST")
     expected = [shared.build_ax25_frame("DEST", "SRC-1", ["W"], info) for info in infos]
     assert sent == expected
     for info in infos:


### PR DESCRIPTION
## Summary
- add APRS message addressee support to telemetry definitions
- update main routine to supply the destination callsign
- update tests for new function signatures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68612c6b4ac883238a674584d800ff2a