### PR TITLE
Fix telemetry BIT definitions for Direwolf

### DIFF
--- a/telemetry/telemetry_defs.py
+++ b/telemetry/telemetry_defs.py
@@ -21,7 +21,16 @@ def _build_def_packets(names, units, bits, addressee):
     parm = prefix + "PARM." + ",".join(names)
     unit = prefix + "UNIT." + ",".join(units + bits)
     eqns = prefix + "EQNS." + ",".join(["0", "1", "0"] * 5)
-    bits_line = prefix + "BITS." + ",".join(bits)
+
+    # The BITS line begins with eight sense digits (0 or 1) which
+    # Direwolf expects before the comma-separated bit names.  Use
+    # ``1`` for defined bits and ``0`` for unused positions.
+    sense = "1" * len([b for b in bits if b])
+    sense = (sense + "0" * 8)[:8]
+
+    bits_line = prefix + "BITS." + sense
+    if bits:
+        bits_line += "," + ",".join(bits)
     return [parm, unit, eqns, bits_line]
 
 

--- a/tests/test_telemetry_defs.py
+++ b/tests/test_telemetry_defs.py
@@ -20,5 +20,9 @@ def test_def_frames(monkeypatch):
     infos = defs.hub_definitions("DEST") + defs.direwolf_definitions("DEST")
     expected = [shared.build_ax25_frame("DEST", "SRC-1", ["W"], info) for info in infos]
     assert sent == expected
+
+    prefix = ":" + "DEST".ljust(9)[:9] + ":"
+    assert infos[3].startswith(prefix + "BITS.11000000")
+    assert infos[7].startswith(prefix + "BITS.00000000")
     for info in infos:
         assert info.startswith(":")


### PR DESCRIPTION
## Summary
- include digital sense bits in `BITS` definition packets
- verify BITS format in tests

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68613292f9508323ad9a732d69a18736