### PR TITLE
Use unique SSIDs for telemetry packets

### DIFF
--- a/telemetry/direwolf_telemetry.py
+++ b/telemetry/direwolf_telemetry.py
@@ -93,6 +93,7 @@ def main(argv=None):
         metrics = {}
 
     callsign, lat, lon, table, symbol, path, dest, ver = config.load_aprs_config("DIREWOLF_TELEMETRY")
+    callsign = utils.callsign_with_offset(callsign, 1)
     info = build_aprs_info(lat, lon, table, symbol, ver, metrics)
     frame = utils.build_ax25_frame(dest, callsign, path, info)
 

--- a/telemetry/hub_telemetry.py
+++ b/telemetry/hub_telemetry.py
@@ -96,6 +96,7 @@ def main(argv=None):
         sys.exit(0)
 
     callsign, latitude, longitude, symbol_table, symbol, path, destination, version = config.load_aprs_config("HUBTELEMETRY")
+    callsign = utils.callsign_with_offset(callsign, 0)
     if args.debug:
         utils.log_info("Config Loaded:", source=LOG_SOURCE)
         utils.log_info(

--- a/telemetry/telemetry_defs.py
+++ b/telemetry/telemetry_defs.py
@@ -58,6 +58,7 @@ def main(argv=None):
     frames = []
     if config.load_hubtelemetry_config().get("enabled", True):
         callsign, lat, lon, table, sym, path, dest, ver = config.load_aprs_config("HUBTELEMETRY")
+        callsign = utils.callsign_with_offset(callsign, 0)
         defs = hub_definitions(dest)
         for info in defs:
             frame = utils.build_ax25_frame(dest, callsign, path, info)
@@ -65,6 +66,7 @@ def main(argv=None):
 
     if config.load_direwolf_config().get("enabled", True):
         callsign, lat, lon, table, sym, path, dest, ver = config.load_aprs_config("DIREWOLF_TELEMETRY")
+        callsign = utils.callsign_with_offset(callsign, 1)
         defs = direwolf_definitions(dest)
         for info in defs:
             frame = utils.build_ax25_frame(dest, callsign, path, info)

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -48,7 +48,7 @@ def test_kiss_frame_generation(monkeypatch):
     dw.main([])
 
     info = dw.build_aprs_info(10.0, -100.0, "/", "Y", "v1", metrics)
-    expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
+    expected = shared.build_ax25_frame("DEST", "SRC-2", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected
     assert info == "T#000,010,002,003,000,000,00000000 ver=v1"
@@ -73,7 +73,7 @@ def test_zero_frame_when_no_metrics(monkeypatch):
     dw.main([])
 
     info = dw.build_aprs_info(10.0, -100.0, "/", "Y", "v1", {})
-    expected = shared.build_ax25_frame("DEST", "SRC-1", ["WIDE1-1"], info)
+    expected = shared.build_ax25_frame("DEST", "SRC-2", ["WIDE1-1"], info)
 
     assert sent and sent[0] == expected
     assert info == "T#000,000,000,000,000,000,00000000 ver=v1"

--- a/tests/test_telemetry_defs.py
+++ b/tests/test_telemetry_defs.py
@@ -17,8 +17,13 @@ def test_def_frames(monkeypatch):
 
     defs.main([])
 
-    infos = defs.hub_definitions("DEST") + defs.direwolf_definitions("DEST")
-    expected = [shared.build_ax25_frame("DEST", "SRC-1", ["W"], info) for info in infos]
+    hub_defs = defs.hub_definitions("DEST")
+    dw_defs = defs.direwolf_definitions("DEST")
+    infos = hub_defs + dw_defs
+    expected = []
+    for i, info in enumerate(infos):
+        callsign = "SRC-1" if i < len(hub_defs) else "SRC-2"
+        expected.append(shared.build_ax25_frame("DEST", callsign, ["W"], info))
     assert sent == expected
 
     prefix = ":" + "DEST".ljust(9)[:9] + ":"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,8 @@
+import utils
+
+
+def test_callsign_with_offset():
+    assert utils.callsign_with_offset("N0CALL-10", 0) == "N0CALL-10"
+    assert utils.callsign_with_offset("N0CALL-10", 1) == "N0CALL-11"
+    assert utils.callsign_with_offset("CALL", 2) == "CALL-2"
+

--- a/utils.py
+++ b/utils.py
@@ -83,6 +83,38 @@ def parse_callsign(full_call: str):
     return base.ljust(6), ssid
 
 
+def callsign_with_offset(full_call: str, offset: int = 0) -> str:
+    """Return ``full_call`` with its SSID incremented by ``offset``.
+
+    Parameters
+    ----------
+    full_call : str
+        Base callsign optionally including an ``-SSID`` suffix.
+    offset : int, optional
+        Amount to add to the existing SSID (default ``0``).
+
+    Returns
+    -------
+    str
+        Callsign string with the updated SSID. If the resulting SSID is ``0``
+        no ``-SSID`` suffix is included.
+    """
+
+    if "-" in full_call:
+        base, ssid = full_call.rsplit("-", 1)
+        if ssid.isdigit():
+            ssid = int(ssid) + offset
+        else:
+            base = full_call
+            ssid = offset
+    else:
+        base, ssid = full_call, offset
+
+    if ssid:
+        return f"{base}-{ssid}"
+    return base
+
+
 def encode_callsign(callsign: str, ssid: int) -> bytearray:
     """Encode a callsign and SSID using AX.25 formatting."""
 


### PR DESCRIPTION
## Summary
- add `callsign_with_offset` helper to utils
- increment SSID for Direwolf telemetry packets
- use unique SSIDs when sending telemetry definitions
- test new callsign helper and updated offsets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619329c8308323bafc8b42b83e781b