### PR TITLE
Use dailyrainin for APRS rainfall

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -96,7 +96,7 @@ def ecowitt_to_aprs(p):
 
     # rainfall
     rain1h  = float(p.get("hourlyrainin", 0))
-    rainmid = float(p.get("eventrainin", 0))           # since local midnight
+    rainmid = float(p.get("dailyrainin", 0))           # rainfall since local midnight
     rRRR = clamp(int(round(rain1h  * 100)), 0, 999)
     PQQQ = clamp(int(round(rainmid * 100)), 0, 999)
     pPPP = clamp(update_rain_24h(p),        0, 999)

--- a/tests/test_ecowitt.py
+++ b/tests/test_ecowitt.py
@@ -27,7 +27,7 @@ def test_temperature_field(temp, expected):
         "windgustmph": "0",
         "tempf": str(temp),
         "hourlyrainin": "0",
-        "eventrainin": "0",
+        "dailyrainin": "0",
         "humidity": "50",
         "baromrelin": "30",
         "dateutc": "2020-01-01 00:00:00",
@@ -51,7 +51,7 @@ def test_wind_speed_field(speed, expected):
         "windgustmph": "0",
         "tempf": "0",
         "hourlyrainin": "0",
-        "eventrainin": "0",
+        "dailyrainin": "0",
         "humidity": "50",
         "baromrelin": "30",
         "dateutc": "2020-01-01 00:00:00",
@@ -99,3 +99,22 @@ def test_format_lat_lon(lat, lon, expected_lat, expected_lon):
     result_lat, result_lon = mod.format_lat_lon(lat, lon)
     assert result_lat == expected_lat
     assert result_lon == expected_lon
+
+
+def test_daily_rainfall_field():
+    """Verify that the APRS packet uses dailyrainin for the P field."""
+    mod = load_module()
+    mod.update_rain_24h = lambda p: 0
+    params = {
+        "winddir": "0",
+        "windspeedmph": "0",
+        "windgustmph": "0",
+        "tempf": "0",
+        "hourlyrainin": "0",
+        "dailyrainin": "0.25",
+        "humidity": "50",
+        "baromrelin": "30",
+        "dateutc": "2020-01-01 00:00:00",
+    }
+    frame = mod.ecowitt_to_aprs(params)
+    assert "P025" in frame


### PR DESCRIPTION
## Summary
- read daily rainfall from `dailyrainin` rather than `eventrainin`
- adjust tests for `dailyrainin`
- add unit test checking the APRS `P` field

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6866893c90f883238b928f10092b4843