### PR TITLE
Add baud rate option for rigctld

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The minimum changes you'll need to make are in ``wx-helios.conf`` to edit your *
 ``Direwolf`` can be used by itself to handle PTT on the radio, or ``rigctld`` is included
 for more options in handling PTT.
 If ``rigctld`` is enabled, be sure that the ``Direwolf`` port for ``rigctld`` is the same
-as is configured for ``rigctld`` in ``wx-helios,conf``.
+as is configured for ``rigctld`` in ``wx-helios,conf``.  The [RIG] section of
+``wx-helios.conf`` can also specify a ``baud`` option if your radio does not
+support automatic baud detection.
 
 ## Running kf6ufo-wx-helios
 

--- a/config.py
+++ b/config.py
@@ -150,5 +150,7 @@ def load_rig_config():
         result["rig_id"] = int(rig.get("rig_id", 0))
     if "usb_num" in rig:
         result["usb_num"] = int(rig.get("usb_num", 0))
+    if "baud" in rig:
+        result["baud"] = int(rig.get("baud"))
     result["port"] = int(rig.get("port", RIGCTLD_PORT))
     return result

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ def start_direwolf():
     return subprocess.Popen(cmd)
 
 
-def start_rigctld(rig_id: int, usb_num: int, port: int):
+def start_rigctld(rig_id: int, usb_num: int, port: int, baud: int | None = None):
     rigctld_bin = (
         PROJECT_ROOT / "external" / "hamlib" / "build" / "tests" / "rigctld"
     )
@@ -67,6 +67,8 @@ def start_rigctld(rig_id: int, usb_num: int, port: int):
         "-t",
         str(port),
     ]
+    if baud is not None:
+        cmd.extend(["-s", str(baud)])
     log_info("Starting rigctld: %s", " ".join(cmd), source=LOG_SOURCE)
     return subprocess.Popen(cmd)
 
@@ -103,6 +105,7 @@ def main():
     parser = argparse.ArgumentParser(description="wx-helios combined launcher")
     parser.add_argument("--rig-id", type=int, help="rig model ID")
     parser.add_argument("--usb-num", type=int, help="/dev/ttyUSB device number")
+    parser.add_argument("--baud", type=int, help="serial speed for rigctld")
     parser.add_argument(
         "--telemetry-interval",
         type=int,
@@ -116,6 +119,8 @@ def main():
         args.rig_id = rig_cfg.get("rig_id")
     if args.usb_num is None:
         args.usb_num = rig_cfg.get("usb_num")
+    if args.baud is None:
+        args.baud = rig_cfg.get("baud")
     if args.rig_id is None or args.usb_num is None:
         parser.error("rig_id and usb_num must be provided via command line or configuration")
 
@@ -128,6 +133,7 @@ def main():
             args.rig_id,
             args.usb_num,
             rig_cfg.get("port", config.RIGCTLD_PORT),
+            args.baud,
         )
     else:
         log_info("rigctld disabled in configuration", source=LOG_SOURCE)

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -47,3 +47,21 @@ def test_telemetry_schedules_values(tmp_path, monkeypatch):
         "foo": "0 * * * *",
         "bar": "*/5 * * * *",
     }
+
+
+def test_rig_config_with_baud(tmp_path, monkeypatch):
+    conf = """[RIG]
+rig_id = 1
+usb_num = 2
+baud = 4800
+port = 9999
+"""
+    write_config(tmp_path, conf, monkeypatch)
+    cfg = config.load_rig_config()
+    assert cfg == {
+        "enabled": True,
+        "rig_id": 1,
+        "usb_num": 2,
+        "baud": 4800,
+        "port": 9999,
+    }

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -97,6 +97,10 @@ enabled = yes
 rig_id = 1
 # USB device number for /dev/ttyUSB{usb_num}
 usb_num = 0
+# Optional baud rate for the serial port. If omitted rigctld uses auto baud
+# detection if supported.
+# Example: 9600
+#baud = 9600
 # TCP port for rigctld (must match PTT RIG port in direwolf.conf)
 port = 4534
 


### PR DESCRIPTION
## Summary
- allow specifying `baud` for rigctld in config or CLI
- document baud option and update config template
- extend tests for new config option

## Testing
- `./tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686be888b2ec8323a5e3d94bced9a37a