### PR TITLE
Update schedules to reduce traffic

### DIFF
--- a/direwolf.conf.template
+++ b/direwolf.conf.template
@@ -14,5 +14,5 @@ AGWPORT 8000
 KISSPORT 8001
 
 # Beacon
-PBEACON delay=1 every=5 lat=10.000 long=-100.000 symbol=/r comment="NOCALL-0, Configure WX Station Direwolf Beacon" dest=APWHE0 via=WIDE2-1
+PBEACON delay=1 every=60 lat=10.000 long=-100.000 symbol=/r comment="NOCALL-0, Configure WX Station Direwolf Beacon" dest=APWHE0 via=WIDE2-1
 

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -61,13 +61,13 @@ digipeater_path = WIDE2-2
 enabled = yes
 symbol_table = primary
 symbol = _
-digipeater_path = WIDE1-1,WIDE2-1
+digipeater_path = WIDE2-1
 
 [DIREWOLF_TELEMETRY]
 # Options for telemetry generated from Direwolf logs
 symbol_table = primary
 symbol = _
-digipeater_path = WIDE1-1,WIDE2-1
+digipeater_path = WIDE2-1
 
 [DAEMONS]
 # Comma-separated list of daemon modules to launch
@@ -81,12 +81,12 @@ modules = telemetry.hub_telemetry, telemetry.direwolf_telemetry, telemetry.telem
 
 [TELEMETRY_SCHEDULES]
 # Cron expressions for individual telemetry modules
-# Run hub telemetry at the top of each hour
-telemetry.hub_telemetry = 0 * * * *
-# Example: poll Dire Wolf telemetry every 5 minutes
-telemetry.direwolf_telemetry = */5 * * * *
-# Transmit telemetry definitions every 6 hours
-telemetry.telemetry_defs = 0 */6 * * *
+# Run hub telemetry every 4 hours
+telemetry.hub_telemetry = 0 */4 * * *
+# Poll Dire Wolf telemetry every 4 hours
+telemetry.direwolf_telemetry = 0 */4 * * *
+# Transmit telemetry definitions every 12 hours
+telemetry.telemetry_defs = 0 */12 * * *
 # Example: run another module every 15 minutes
 #other.module = */15 * * * *
 


### PR DESCRIPTION
## Summary
- reduce digipeater hops for telemetry packets
- throttle ecowitt listener to send at most once every 5 minutes
- lower beacon frequency in `direwolf.conf.template`
- schedule telemetry modules every four hours and definitions every 12 hours

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686c6e8bd41083238fa05d0335253a47