### PR TITLE
Update default callsign

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -33,7 +33,7 @@ try:
         _version,
     ) = config.load_aprs_config("ECOWITT")
 except Exception:
-    _callsign = "NOCALL"
+    _callsign = "NOCALL-13"
     _lat_dd = 0.0
     _lon_dd = 0.0
     _symbol_table = "/"

--- a/direwolf.conf.template
+++ b/direwolf.conf.template
@@ -5,7 +5,7 @@ ADEVICE plughw:1,0
 
 # Channel 0
 CHANNEL 0
-MYCALL NOCALL-0
+MYCALL NOCALL-13
 MODEM 1200
 PTT RIG 2 localhost:4534   # must match [RIG]/port in wx-helios.conf
 
@@ -14,5 +14,5 @@ AGWPORT 8000
 KISSPORT 8001
 
 # Beacon
-PBEACON delay=1 every=60 lat=10.000 long=-100.000 symbol=/r comment="NOCALL-0, Configure WX Station Direwolf Beacon" dest=APWHE0 via=WIDE2-1
+PBEACON delay=1 every=60 lat=10.000 long=-100.000 symbol=/r comment="NOCALL-13, Configure WX Station Direwolf Beacon" dest=APWHE0 via=WIDE2-1
 

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -3,8 +3,8 @@
 # Copy this file to "wx-helios.conf" and edit the values for your station.
 
 [APRS]
-# Your callsign-SSID (replace NOCALL-10 with your real callsign)
-callsign = NOCALL-10
+# Your callsign-SSID (replace NOCALL-13 with your real callsign)
+callsign = NOCALL-13
 
 # Latitude in decimal degrees (positive for North, negative for South)
 latitude = 10.0


### PR DESCRIPTION
## Summary
- update default callsign in example config
- update Direwolf template with new callsign
- adjust Ecowitt listener fallback callsign

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d1f3258c08323bfaac17427cf97c7