### PR TITLE
Add optional APRS-IS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ cp direwolf.conf.template direwolf.conf
 The files contains configuration settings for the ``Direwolf TNC`` and **kf6ufo-wx-helios**.
 The minimum changes you'll need to make are in ``wx-helios.conf`` to edit your **callsign**,
 **latitude** and **longitude**.
+To forward packets to APRS-IS set the options in the ``[APRS_IS]`` section with
+your passcode and server details.
 
 ``Direwolf`` can be used by itself to handle PTT on the radio, or ``rigctld`` is included
 for more options in handling PTT.

--- a/config.py
+++ b/config.py
@@ -139,6 +139,22 @@ def load_kiss_client_config():
     }
 
 
+def load_aprsis_config():
+    cfg = _get_config()
+    section = "APRS_IS"
+    if section not in cfg:
+        return {"enabled": False}
+    sec = cfg[section]
+    callsign = sec.get("callsign", cfg["APRS"].get("callsign"))
+    return {
+        "enabled": sec.getboolean("enabled", False),
+        "callsign": callsign,
+        "passcode": sec.get("passcode", ""),
+        "server": sec.get("server", "rotate.aprs2.net"),
+        "port": int(sec.get("port", 14580)),
+    }
+
+
 def load_rig_config():
     cfg = _get_config()
     section = "RIG"

--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -30,7 +30,7 @@ try:
         _symbol,
         _digipeater_path,
         _dest,
-        _version,
+    _version,
     ) = config.load_aprs_config("ECOWITT")
 except Exception:
     _callsign = "NOCALL-13"
@@ -41,6 +41,11 @@ except Exception:
     _digipeater_path = []
     _dest = "APZ001"
     _version = ""
+
+try:
+    APRS_IS_CFG = config.load_aprsis_config()
+except Exception:
+    APRS_IS_CFG = {"enabled": False}
 
 def format_lat_lon(lat, lon):
     """Return APRS-formatted latitude and longitude strings."""
@@ -168,6 +173,14 @@ def log_params(client, params):
     utils.log_info(info, source=LOG_SOURCE)
     ax25 = utils.build_ax25_frame(_dest, _callsign, _digipeater_path, info)
     utils.send_via_kiss(ax25)
+    if APRS_IS_CFG.get("enabled"):
+        tnc2 = utils.build_tnc2_frame(
+            _dest,
+            APRS_IS_CFG.get("callsign", _callsign),
+            _digipeater_path,
+            info,
+        )
+        utils.send_via_aprsis(tnc2)
     LAST_TX = now
 
 

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -65,3 +65,22 @@ port = 9999
         "baud": 4800,
         "port": 9999,
     }
+
+
+def test_aprsis_default(tmp_path, monkeypatch):
+    write_config(tmp_path, "", monkeypatch)
+    assert config.load_aprsis_config() == {"enabled": False}
+
+
+def test_aprsis_values(tmp_path, monkeypatch):
+    conf = """[APRS]\ncallsign = N0CALL\nlatitude = 0\nlongitude = 0\n
+[APRS_IS]\nenabled = yes\npasscode = 2222\nserver = test.example\nport = 1234\n"""
+    write_config(tmp_path, conf, monkeypatch)
+    cfg = config.load_aprsis_config()
+    assert cfg == {
+        "enabled": True,
+        "callsign": "N0CALL",
+        "passcode": "2222",
+        "server": "test.example",
+        "port": 1234,
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,3 +6,8 @@ def test_callsign_with_offset():
     assert utils.callsign_with_offset("N0CALL-10", 1) == "N0CALL-11"
     assert utils.callsign_with_offset("CALL", 2) == "CALL-2"
 
+
+def test_build_tnc2_frame():
+    frame = utils.build_tnc2_frame("DEST", "SRC", ["W1", "W2"], "HELLO")
+    assert frame == "SRC>DEST,W1,W2:HELLO"
+

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -116,3 +116,19 @@ port = 8001
 # When the KISS client daemon is active, it exposes a multiprocessing queue
 # using environment variables KISS_MANAGER_HOST, KISS_MANAGER_PORT and
 # KISS_MANAGER_AUTHKEY for telemetry modules.
+
+[APRS_IS]
+# Enable sending packets to APRS-IS
+enabled = no
+
+# Callsign for the APRS-IS connection
+callsign = NOCALL-13
+
+# Passcode for APRS-IS authentication
+passcode = 12345
+
+# Server hostname for APRS-IS
+server = rotate.aprs2.net
+
+# TCP port for APRS-IS
+port = 14580


### PR DESCRIPTION
## Summary
- allow configuring APRS-IS connection
- add helper to build TNC2 frames and transmit via aprslib
- send Ecowitt packets to APRS-IS when enabled
- document APRS-IS settings
- tests for new config loader and utilities

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686d53693cfc832380e703898980f1c3