### PR TITLE
Fix APRS‑IS hang by adding connect timeout

### DIFF
--- a/config.py
+++ b/config.py
@@ -152,6 +152,7 @@ def load_aprsis_config():
         "passcode": sec.get("passcode", ""),
         "server": sec.get("server", "rotate.aprs2.net"),
         "port": int(sec.get("port", 14580)),
+        "timeout": float(sec.get("timeout", 10)),
     }
 
 

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -73,8 +73,11 @@ def test_aprsis_default(tmp_path, monkeypatch):
 
 
 def test_aprsis_values(tmp_path, monkeypatch):
-    conf = """[APRS]\ncallsign = N0CALL\nlatitude = 0\nlongitude = 0\n
-[APRS_IS]\nenabled = yes\npasscode = 2222\nserver = test.example\nport = 1234\n"""
+    conf = (
+        "[APRS]\ncallsign = N0CALL\nlatitude = 0\nlongitude = 0\n"
+        "[APRS_IS]\nenabled = yes\npasscode = 2222\nserver = test.example\n"
+        "port = 1234\ntimeout = 5\n"
+    )
     write_config(tmp_path, conf, monkeypatch)
     cfg = config.load_aprsis_config()
     assert cfg == {
@@ -83,4 +86,5 @@ def test_aprsis_values(tmp_path, monkeypatch):
         "passcode": "2222",
         "server": "test.example",
         "port": 1234,
+        "timeout": 5.0,
     }

--- a/utils.py
+++ b/utils.py
@@ -282,16 +282,26 @@ def send_via_aprsis(tnc2_frame):
         return
     try:
         import aprslib
+        import socket
     except Exception:
         log_error("aprslib is not available", source=__name__)
         return
 
+    class _IS(aprslib.IS):
+        def __init__(self, *args, timeout=10, **kwargs):
+            self._timeout = timeout
+            super().__init__(*args, **kwargs)
+
+        def _open_socket(self):
+            self.sock = socket.create_connection(self.server, self._timeout)
+
     try:
-        ais = aprslib.IS(
+        ais = _IS(
             cfg.get("callsign"),
             cfg.get("passcode"),
             host=cfg.get("server"),
             port=cfg.get("port"),
+            timeout=cfg.get("timeout", 10),
         )
         ais.connect()
         ais.sendall(tnc2_frame)

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -132,3 +132,6 @@ server = rotate.aprs2.net
 
 # TCP port for APRS-IS
 port = 14580
+
+# Connection timeout in seconds when contacting APRS-IS
+timeout = 10


### PR DESCRIPTION
## Summary
- set APRS-IS connection timeout in configuration
- support the new timeout field in `load_aprsis_config`
- limit APRS-IS socket timeout in `send_via_aprsis`
- document the timeout option
- update unit test for APRS-IS config

## Testing
- `./tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687081b3586c8323b10de24cf0a9f220