### PR TITLE
Fix APRS-IS hang and add logging

### DIFF
--- a/tests/test_aprsis.py
+++ b/tests/test_aprsis.py
@@ -1,0 +1,39 @@
+import utils
+import config
+from unittest.mock import patch
+
+class DummySocket:
+    def __init__(self):
+        self.sent = b""
+    def sendall(self, data):
+        self.sent += data
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+def test_send_via_aprsis(monkeypatch):
+    dummy = DummySocket()
+    captured = {}
+    def fake_create(addr, timeout=None):
+        captured['addr'] = addr
+        captured['timeout'] = timeout
+        return dummy
+
+    monkeypatch.setattr(utils.socket, 'create_connection', fake_create)
+    monkeypatch.setattr(config, 'load_aprsis_config', lambda: {
+        'enabled': True,
+        'callsign': 'N0CALL',
+        'passcode': '11111',
+        'server': 'host',
+        'port': 2020,
+        'timeout': 3,
+    })
+
+    utils.send_via_aprsis('SRC>DEST:HELLO')
+
+    assert captured['addr'] == ('host', 2020)
+    assert captured['timeout'] == 3
+    expected = b"user N0CALL pass 11111 vers wx-helios 0\r\nSRC>DEST:HELLO\r\n"
+    assert dummy.sent == expected
+


### PR DESCRIPTION
## Summary
- avoid aprslib blocking by using a simple socket implementation for APRS‑IS
- log APRS‑IS connection attempts and success/failure
- test sending to APRS‑IS using a dummy socket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f0b07fb483239c8db49368fde973