### PR TITLE
Remove unused mock imports in tests

### DIFF
--- a/tests/test_aprsis.py
+++ b/tests/test_aprsis.py
@@ -1,6 +1,5 @@
 import utils
 import config
-from unittest.mock import patch
 import sys
 import importlib.machinery
 import importlib.util

--- a/tests/test_direwolf_telemetry.py
+++ b/tests/test_direwolf_telemetry.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest.mock import patch
 
 pytest.importorskip("psutil")
 


### PR DESCRIPTION
## Summary
- clean up unused imports in aprsis and direwolf telemetry tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687111b42ed88323ad45fe0b3243cc9f