### PR TITLE
Fix APRS-IS daemon instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ The files contains configuration settings for the ``Direwolf TNC`` and **kf6ufo-
 The minimum changes you'll need to make are in ``wx-helios.conf`` to edit your **callsign**,
 **latitude** and **longitude**.
 To forward packets to APRS-IS set the options in the ``[APRS_IS]`` section with
-your passcode and server details.
+your passcode and server details. When enabling APRS-IS, also add ``daemons.aprsis_client``
+to the module list in the ``[DAEMONS]`` section so the APRS-IS client starts.
 
 ``Direwolf`` can be used by itself to handle PTT on the radio, or ``rigctld`` is included
 for more options in handling PTT.

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -72,7 +72,8 @@ digipeater_path = WIDE2-1
 [DAEMONS]
 # Comma-separated list of daemon modules to launch
 enabled = yes
-modules = daemons.ecowitt_listener, daemons.kiss_client
+# Include ``daemons.aprsis_client`` when APRS-IS support is desired
+modules = daemons.ecowitt_listener, daemons.kiss_client, daemons.aprsis_client
 
 [TELEMETRY]
 # Comma-separated list of telemetry modules to run periodically


### PR DESCRIPTION
## Summary
- include `daemons.aprsis_client` in the example DAEMONS list
- document that the APRS-IS daemon must be enabled to start the APRS-IS client

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68711d4739688323b38034139ef4080b