### PR TITLE
Fix local build of direwolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,17 @@ The same Python code can be deployed on at least three target platforms:
 This repository includes the
 [wx-helios-direwolf](https://github.com/kf6ufo/wx-helios-direwolf) and
 [wx-helios-hamlib](https://github.com/kf6ufo/wx-helios-hamlib) submodules used
-to provide the Direwolf TNC and the `rigctld` daemon. Simply run the build
-script to fetch the latest sources and compile both projects. Hamlib is built
-first so Direwolf can detect the libraries and use the correct ``rigctld``.
+to provide the Direwolf TNC and the `rigctld` daemon. Before building, install
+the required development packages so CMake can locate ALSA and other
+dependencies:
+
+```bash
+sudo apt-get install build-essential cmake libasound2-dev pkg-config
+```
+
+After installing the dependencies, run the build script to fetch the latest
+sources and compile both projects. Hamlib is built first so Direwolf can detect
+the libraries and use the correct ``rigctld``.
 
 ```bash
 ./build_external.sh

--- a/build_external.sh
+++ b/build_external.sh
@@ -30,14 +30,15 @@ build_hamlib() {
     git submodule update --init --remote "$path"
     cd "$path"
     ./bootstrap
-    mkdir -p build
+    mkdir -p build install
     cd build
 
-    # Configure and build Hamlib without installing it. The rigctld binary will
-    # remain under the build/tests directory.
-    ../configure CFLAGS="-g -O0"
+    # Configure and build Hamlib.  Install into a local prefix so Direwolf can
+    # locate the library without needing root privileges.
+    ../configure --prefix="$ROOT_DIR/external/hamlib/install" CFLAGS="-g -O0"
     make -j"$(nproc)"
     make check
+    make install
 
     cd ../../..
 }
@@ -49,8 +50,9 @@ build_direwolf() {
     cd "$path"
     mkdir -p build
     cd build
-    local hamlib_root="$ROOT_DIR/external/hamlib/build"
-    cmake .. -DHAMLIB_ROOT_DIR="$hamlib_root"
+    local hamlib_root="$ROOT_DIR/external/hamlib/install"
+    export PKG_CONFIG_PATH="$hamlib_root/lib/pkgconfig:$PKG_CONFIG_PATH"
+    cmake .. -DHAMLIB_ROOT_DIR="$hamlib_root" -DCMAKE_PREFIX_PATH="$hamlib_root"
     make -j"$(nproc)"
     cd ../../..
 }


### PR DESCRIPTION
## Summary
- install hamlib into a local prefix
- let `build_external.sh` expose hamlib via `PKG_CONFIG_PATH`
- mention required packages in the README

## Testing
- `./tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687547f261dc83238f4391f217f33da0