### PR TITLE
Fix hamlib install path

### DIFF
--- a/build_external.sh
+++ b/build_external.sh
@@ -33,12 +33,12 @@ build_hamlib() {
     mkdir -p build install
     cd build
 
-    # Configure and build Hamlib.  Install into a local prefix so Direwolf can
-    # locate the library without needing root privileges.
-    ../configure --prefix="$ROOT_DIR/external/hamlib/install" CFLAGS="-g -O0"
+    # Configure and build Hamlib.  Install into a local directory using
+    # DESTDIR so libtool does not insist on a system prefix.
+    ../configure --prefix=/usr/local CFLAGS="-g -O0"
     make -j"$(nproc)"
     make check
-    make install
+    make DESTDIR="$ROOT_DIR/external/hamlib/install" install
 
     cd ../../..
 }
@@ -50,7 +50,7 @@ build_direwolf() {
     cd "$path"
     mkdir -p build
     cd build
-    local hamlib_root="$ROOT_DIR/external/hamlib/install"
+    local hamlib_root="$ROOT_DIR/external/hamlib/install/usr/local"
     export PKG_CONFIG_PATH="$hamlib_root/lib/pkgconfig:$PKG_CONFIG_PATH"
     cmake .. -DHAMLIB_ROOT_DIR="$hamlib_root" -DCMAKE_PREFIX_PATH="$hamlib_root"
     make -j"$(nproc)"


### PR DESCRIPTION
## Summary
- install hamlib using DESTDIR
- adjust direwolf build to look in the new subdirectory

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687550eba3108323a1cc4fe64a3c517c