### PR TITLE
Add automatic venv package installation for tests

### DIFF
--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -16,7 +16,26 @@ fi
 
 # Create the environment if needed
 if [ ! -x "$VENV_DIR/bin/python" ]; then
-    python3 -m venv "$VENV_DIR"
+    if ! python3 -m venv "$VENV_DIR" 2>/dev/null; then
+        # Some minimal Ubuntu/Debian installs lack the ensurepip module which
+        # causes `python3 -m venv` to fail. Attempt to install the appropriate
+        # python3-venv package so tests can run out of the box.
+        if command -v apt-get >/dev/null; then
+            PY_VENV_PKG="python$(python3 -c 'import sys;print(f"{sys.version_info.major}.{sys.version_info.minor}")')-venv"
+            echo "Installing $PY_VENV_PKG to enable Python virtual environments..."
+            if command -v sudo >/dev/null; then
+                sudo apt-get update && sudo apt-get install -y "$PY_VENV_PKG"
+            else
+                apt-get update && apt-get install -y "$PY_VENV_PKG"
+            fi
+            rm -rf "$VENV_DIR"
+            python3 -m venv "$VENV_DIR"
+        else
+            echo "Failed to create Python virtual environment and automatic installation is not available." >&2
+            echo "Please install the appropriate python3-venv package for your system." >&2
+            exit 1
+        fi
+    fi
 fi
 
 # Activate the environment so any subprocesses use its tools


### PR DESCRIPTION
## Summary
- upgrade tests/runTests.sh to handle missing `python3-venv`
  - automatically install the distro package on apt-based systems
  - retry venv creation after installation

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875650cd29483238a60b59815443ca7