### PR TITLE
Update APRS-IS default server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,11 @@ The files contains configuration settings for the ``Direwolf TNC`` and **kf6ufo-
 The minimum changes you'll need to make are in ``wx-helios.conf`` to edit your **callsign**,
 **latitude** and **longitude**.
 To forward packets to APRS-IS set the options in the ``[APRS_IS]`` section with
-your passcode and server details. When enabling APRS-IS, also add ``daemons.aprsis_client``
-to the module list in the ``[DAEMONS]`` section so the APRS-IS client starts.
+your passcode and server details. The configuration template defaults the server
+to ``noam.aprs2.net`` which is recommended for North American clients. Adjust
+the ``server`` option if you are in a different region. When enabling APRS-IS,
+also add ``daemons.aprsis_client`` to the module list in the ``[DAEMONS]``
+section so the APRS-IS client starts.
 
 ``Direwolf`` can be used by itself to handle PTT on the radio, or ``rigctld`` is included
 for more options in handling PTT.

--- a/config.py
+++ b/config.py
@@ -150,7 +150,7 @@ def load_aprsis_config():
         "enabled": sec.getboolean("enabled", False),
         "callsign": callsign,
         "passcode": sec.get("passcode", ""),
-        "server": sec.get("server", "rotate.aprs2.net"),
+        "server": sec.get("server", "noam.aprs2.net"),
         "port": int(sec.get("port", 14580)),
         "timeout": float(sec.get("timeout", 10)),
     }

--- a/wx-helios.conf.template
+++ b/wx-helios.conf.template
@@ -129,7 +129,7 @@ callsign = NOCALL-13
 passcode = 12345
 
 # Server hostname for APRS-IS
-server = rotate.aprs2.net
+server = noam.aprs2.net
 
 # TCP port for APRS-IS
 port = 14580


### PR DESCRIPTION
## Summary
- use `noam.aprs2.net` as the default APRS-IS server
- mention recommended host in README

## Testing
- `tests/runTests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877d530dd788323b8c1c959d757c9b1