### PR TITLE
Improve config error logging for ecowitt listener

### DIFF
--- a/daemons/ecowitt_listener.py
+++ b/daemons/ecowitt_listener.py
@@ -30,9 +30,12 @@ try:
         _symbol,
         _digipeater_path,
         _dest,
-    _version,
+        _version,
     ) = config.load_aprs_config("ECOWITT")
-except Exception:
+except Exception as exc:
+    utils.log_exception(
+        "Falling back to default APRS config: %s", exc, source=LOG_SOURCE
+    )
     _callsign = "NOCALL-13"
     _lat_dd = 0.0
     _lon_dd = 0.0


### PR DESCRIPTION
## Summary
- add log message when APRS config fails in `ecowitt_listener`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'croniter')*

------
https://chatgpt.com/codex/tasks/task_e_687aa78710ac83239d22406fb2853119