### PR TITLE
Handle Unicode minus signs in APRS config parsing

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,22 @@ def _get_config():
         _config = parser
     return _config
 
+_UNICODE_MINUS_TRANSLATION = str.maketrans({
+    "\u2212": "-",  # minus sign
+    "\u2013": "-",  # en dash
+    "\u2014": "-",  # em dash
+    "\u2015": "-",  # horizontal bar
+})
+
+
+def _parse_float(value: str) -> float:
+    """Parse a float while normalising Unicode minus characters."""
+
+    if isinstance(value, str):
+        value = value.translate(_UNICODE_MINUS_TRANSLATION)
+    return float(value)
+
+
 def load_aprs_config(section: str | None = None):
     """Return APRS configuration, optionally overridden per module.
 
@@ -35,8 +51,8 @@ def load_aprs_config(section: str | None = None):
     aprs = cfg["APRS"]
 
     callsign = aprs["callsign"]
-    latitude = float(aprs["latitude"])
-    longitude = float(aprs["longitude"])
+    latitude = _parse_float(aprs["latitude"])
+    longitude = _parse_float(aprs["longitude"])
 
     symbol_table_raw = aprs.get("symbol_table", "primary").strip().lower()
     symbol_table = "/" if symbol_table_raw == "primary" else "\\"

--- a/tests/test_config_sections.py
+++ b/tests/test_config_sections.py
@@ -18,6 +18,19 @@ def test_daemons_default(tmp_path, monkeypatch):
     ]
 
 
+def test_aprs_unicode_minus(tmp_path, monkeypatch):
+    conf = (
+        "[APRS]\n"
+        "callsign = N0CALL-1\n"
+        "latitude = 37.7653\n"
+        "longitude = −108.9010\n"
+    )
+    write_config(tmp_path, conf, monkeypatch)
+    cfg = config.load_aprs_config()
+    assert cfg[1] == 37.7653
+    assert cfg[2] == -108.901
+
+
 def test_daemons_disabled(tmp_path, monkeypatch):
     write_config(tmp_path, "[DAEMONS]\nenabled = no\nmodules = a,b\n", monkeypatch)
     assert config.load_daemon_modules() == []


### PR DESCRIPTION
## Summary
- normalize Unicode dash and minus characters before parsing APRS latitude and longitude
- add a regression test that covers Unicode minus longitude values

## Testing
- pytest tests/test_config_sections.py

------
https://chatgpt.com/codex/tasks/task_e_68f4cdfb8638832393c5d657965d0f02